### PR TITLE
Use JsRenderInterface $variable instead of string selector

### DIFF
--- a/src/Js/JsChain.php
+++ b/src/Js/JsChain.php
@@ -28,10 +28,10 @@ class JsChain implements JsRenderInterface
     /** @var Chainable[] The remaining chaining methods or property. */
     protected array $chains = [];
 
-    final protected function __construct(string $library, JsRenderInterface $selector = null)
+    final protected function __construct(string $library, JsRenderInterface $variable = null)
     {
-        if ($selector) {
-            $this->arguments[] = $selector;
+        if ($variable) {
+            $this->arguments[] = $variable;
         }
 
         $this->libraryName = $library;
@@ -39,20 +39,16 @@ class JsChain implements JsRenderInterface
 
     /**
      * Start of the chain.
-     * ex: Js::with('flatpickr') translate into flatpickr().
+     * ex: Js::with('flatpickr', Js::var('')) translate into flatpickr().
      */
-    public static function with(string $library, string $selector = null): self
+    public static function with(string $library, JsRenderInterface $variable = null): self
     {
-        if ($selector) {
-            return new static($library, Js::string($selector));
-        }
-
-        return new static($library);
+        return new static($library, $variable);
     }
 
-    public static function withUiLibrary(string $selector = null): self
+    public static function withUiLibrary(JsRenderInterface $variable = null): self
     {
-        return self::with(Ui::service()->jsLibrary, $selector);
+        return self::with(Ui::service()->jsLibrary, $variable);
     }
 
     /**

--- a/tests/Javascript/JsBasicTest.php
+++ b/tests/Javascript/JsBasicTest.php
@@ -59,8 +59,28 @@ class JsBasicTest extends TestCase
         $chain = JsChain::with('myLibrary')->doMyLibraryFunction();
         $this->assertSame('myLibrary.doMyLibraryFunction()', $chain->jsRender());
 
+        // Test calling chain function with var selector.
+        $chain = JsChain::with('myLibrary', Js::var('selector'))->doMyLibraryFunction();
+        $this->assertSame('myLibrary(selector).doMyLibraryFunction()', $chain->jsRender());
+
+        // Test calling chain function with string selector.
+        $chain = JsChain::with('myLibrary', Js::string('selector'))->doMyLibraryFunction();
+        $this->assertSame('myLibrary(\'selector\').doMyLibraryFunction()', $chain->jsRender());
+
+        // Test calling chain function with object selector.
+        $chain = JsChain::with('myLibrary', Js::object(['aProp' => 'aValue']))->doMyLibraryFunction();
+        $this->assertSame('myLibrary({aProp:\'aValue\'}).doMyLibraryFunction()', $chain->jsRender());
+
+        // Test calling chain function with array selector.
+        $chain = JsChain::with('myLibrary', Js::array(['a', 'b']))->doMyLibraryFunction();
+        $this->assertSame('myLibrary([\'a\',\'b\']).doMyLibraryFunction()', $chain->jsRender());
+
+        // Test calling chain function with empty var selector.
+        $chain = JsChain::with('myLibrary', Js::var(''))->doMyLibraryFunction();
+        $this->assertSame('myLibrary().doMyLibraryFunction()', $chain->jsRender());
+
         // Test chaining.
-        $chain->callAnotherFunction();
+        $chain = JsChain::with('myLibrary')->doMyLibraryFunction()->callAnotherFunction();
         $this->assertSame('myLibrary.doMyLibraryFunction().callAnotherFunction()', $chain->jsRender());
 
         // test chain property


### PR DESCRIPTION
Offer more flexibility when chaining Js library.
- myLib
- myLib()
- myLib('string')
- myLib(myVar)
- myLib({})
- myLib([])