### PR TITLE
Feature/improve table component

### DIFF
--- a/app-test/collection/table.php
+++ b/app-test/collection/table.php
@@ -9,7 +9,6 @@ use Fohn\Ui\Component\Form\Control\Select;
 use Fohn\Ui\Component\Table;
 use Fohn\Ui\Js\Js;
 use Fohn\Ui\Js\JsFunction;
-use Fohn\Ui\Js\JsReload;
 use Fohn\Ui\Service\Ui;
 use Fohn\Ui\Tailwind\Theme\TwConstant;
 use Fohn\Ui\Tailwind\Tw;
@@ -46,7 +45,7 @@ $select->setItems($locales);
 $table = Table::addTo($grid, ['hasTableSearch' => false, 'hasPaginator' => false]);
 $table->setCaption(AppTest::tableCaptionFactory('Sales Report'));
 $select->onChange(JsFunction::arrow([Js::var('selectLocale')])->executes([
-    $table->jsDataRequest(['loc' => Js::var('selectLocale')])
+    $table->jsDataRequest(['loc' => Js::var('selectLocale')]),
 ]));
 
 // Locale get argument to table callback.

--- a/app-test/collection/table.php
+++ b/app-test/collection/table.php
@@ -9,6 +9,7 @@ use Fohn\Ui\Component\Form\Control\Select;
 use Fohn\Ui\Component\Table;
 use Fohn\Ui\Js\Js;
 use Fohn\Ui\Js\JsFunction;
+use Fohn\Ui\Js\JsReload;
 use Fohn\Ui\Service\Ui;
 use Fohn\Ui\Tailwind\Theme\TwConstant;
 use Fohn\Ui\Tailwind\Tw;
@@ -41,12 +42,12 @@ $subtitles = [
 
 $select = Select::addTo($grid, ['controlName' => 'loc_select', 'allowNull' => false, 'caption' => 'Select locale for displaying data:'], 'rightContent');
 $select->setItems($locales);
-$select->onChange(JsFunction::arrow([Js::var('e')])->executes([
-    Ui::jsRedirect(Ui::parseRequestUrl(), ['loc' => Js::var('e')]),
-]));
 
 $table = Table::addTo($grid, ['hasTableSearch' => false, 'hasPaginator' => false]);
 $table->setCaption(AppTest::tableCaptionFactory('Sales Report'));
+$select->onChange(JsFunction::arrow([Js::var('selectLocale')])->executes([
+    $table->jsDataRequest(['loc' => Js::var('selectLocale')])
+]));
 
 // Locale get argument to table callback.
 $locale = $table->stickyGet('loc', 'en_US');

--- a/src/Component/Table.php
+++ b/src/Component/Table.php
@@ -119,6 +119,15 @@ class Table extends View implements VueInterface
         return $column;
     }
 
+    public function addColumns(array $columns): self
+    {
+        foreach ($columns as $name => $column) {
+            $this->addColumn($name, $column);
+        }
+
+        return $this;
+    }
+
     public function hasColumn(string $name): bool
     {
         return isset($this->columns[$name]);
@@ -196,6 +205,11 @@ class Table extends View implements VueInterface
     public function jsDeleteRow(string $id): JsRenderInterface
     {
         return $this->getStoreChain()->deleteRow($id);
+    }
+
+    public function jsDataRequest(array $args = []): JsRenderInterface
+    {
+        return $this->getStoreChain()->fetchItems(Js::object($args));
     }
 
     private function getStoreChain(): JsRenderInterface

--- a/src/Component/Table.php
+++ b/src/Component/Table.php
@@ -212,6 +212,7 @@ class Table extends View implements VueInterface
 
     public function jsDataRequest(array $args = []): JsRenderInterface
     {
+        // @phpstan-ignore-next-line
         return $this->getStoreChain()->fetchItems(Js::object($args));
     }
 

--- a/src/Component/Table.php
+++ b/src/Component/Table.php
@@ -58,6 +58,9 @@ class Table extends View implements VueInterface
     public bool $hasColumnsHeader = true;
     public bool $hasTableSearch = true;
 
+    /** Will keep table state on refresh. */
+    public bool $keepTableState = true;
+
     public bool $hasPaginator = true;
     public int $paginatorLimit = 5;
     public int $paginatorItemsPerPage = 10;
@@ -76,7 +79,7 @@ class Table extends View implements VueInterface
         'w-full',
         'border',
         'border-collapse',
-        'table-fixed',
+        'table-auto'
     ];
 
     protected array $rowTws = [
@@ -285,6 +288,7 @@ class Table extends View implements VueInterface
     {
         $this->getTemplate()->set('storeId', $this->getPiniaStoreId(self::PINIA_PREFIX));
         $this->getTemplate()->set('dataUrl', $this->tableDataCb->getUrl());
+        $this->getTemplate()->setJs('keepTableState', Js::boolean($this->keepTableState));
         $this->getTemplate()->setJs('columns', ArrayLiteral::set($this->getColumnsDefinition()));
         $this->getTemplate()->setJs('itemsPerPage', Integer::set($this->paginatorItemsPerPage));
         $this->getTemplate()->setJs('tableActions', ObjectLiteral::set($this->actions));

--- a/src/Component/Table.php
+++ b/src/Component/Table.php
@@ -79,7 +79,7 @@ class Table extends View implements VueInterface
         'w-full',
         'border',
         'border-collapse',
-        'table-auto'
+        'table-auto',
     ];
 
     protected array $rowTws = [

--- a/src/Component/VueTrait.php
+++ b/src/Component/VueTrait.php
@@ -23,7 +23,7 @@ trait VueTrait
 
     protected function getPiniaStoreId(string $prefix = ''): string
     {
-        return $prefix . Ui::service()->factoryId(Ui::serverRequest()->getServerParams()['REQUEST_URI'])  . '-' . $this->getIdAttribute();
+        return $prefix . Ui::service()->factoryId(Ui::serverRequest()->getServerParams()['REQUEST_URI']) . '-' . $this->getIdAttribute();
     }
 
     public function isRootComponent(): bool

--- a/src/Component/VueTrait.php
+++ b/src/Component/VueTrait.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Fohn\Ui\Component;
 
 use Fohn\Ui\Js\JsChain;
+use Fohn\Ui\Service\Ui;
 use Fohn\Ui\View;
 
 trait VueTrait
@@ -22,7 +23,7 @@ trait VueTrait
 
     protected function getPiniaStoreId(string $prefix = ''): string
     {
-        return $prefix . $this->getIdAttribute();
+        return $prefix . Ui::service()->factoryId(Ui::serverRequest()->getServerParams()['REQUEST_URI'])  . '-' . $this->getIdAttribute();
     }
 
     public function isRootComponent(): bool

--- a/src/Page.php
+++ b/src/Page.php
@@ -34,7 +34,7 @@ class Page extends View
             'url' => 'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js',
         ],
         'fohn-js' => [
-            'url' => 'https://unpkg.com/fohn-ui@1.0.1/dist/fohn-ui.min.js',
+            'url' => 'https://unpkg.com/fohn-ui@1.1.0/dist/fohn-ui.min.js',
         ],
     ];
 

--- a/template/tailwind/page.html
+++ b/template/tailwind/page.html
@@ -4,10 +4,6 @@
     <title>{title}Fohn UI - Untitled Project{/}</title>{$meta}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
-    <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png">
-    <link rel="manifest" href="/favicons/site.webmanifest">
     {$head}
     {$includeJs}
     {$includeCss}

--- a/template/tailwind/vue-component/table.html
+++ b/template/tailwind/vue-component/table.html
@@ -8,6 +8,7 @@
                 ref="root"
                 class="invisible"
                 :actions="{$tableActions}"
+                :keep-table-state="{$keepTableState}"
                 #default="@{isFetching,
                 query,
                 columns,
@@ -46,6 +47,7 @@
                     </div>
                 </div>
                 {/TableSearch}
+                <div class="overflow-auto">
                 <table class="{$tableTws}" >
                     <caption>{$caption}</caption>
                     {TableHeaders}
@@ -75,6 +77,7 @@
                         </template>
                     </tbody>
                 </table>
+                </div>
                 {$afterTable}
                 {Paginator}
                 <div class="py-4">

--- a/template/tailwind/vue-component/table.html
+++ b/template/tailwind/vue-component/table.html
@@ -108,7 +108,7 @@
                                         </button>
                                     </li>
                                     <li class="w-8 h-8 table-cell">
-                                        <button @click="goToPage(currentPage - 1)"
+                                        <button @click="goToPage(currentPage - 1)" @click.alt="goToPage(currentPage - range.length)"
                                                 :disabled="currentPage === 1"
                                                 class="disabled:text-gray-400  hover:bg-blue-100 w-full h-full transition duration-100 ease-in-out focus:ring-2 focus:ring-blue-500 focus:outline-none focus:ring-opacity-50">
                                             <i class="bi bi-chevron-left"></i>
@@ -124,7 +124,7 @@
                                         </li>
                                     </template>
                                     <li class="w-8 h-8 table-cell">
-                                        <button @click="goToPage(currentPage + 1)"
+                                        <button @click="goToPage(currentPage + 1)" @click.alt="goToPage(currentPage + range.length)"
                                                 :disabled="currentPage === totalPages"
                                                 class="disabled:text-gray-400 hover:bg-blue-100 w-full h-full transition duration-100 ease-in-out focus:ring-2 focus:ring-blue-500 focus:outline-none focus:ring-opacity-50">
                                             <i class="bi bi-chevron-right"></i>


### PR DESCRIPTION
 Udate Js dependancy to fohn-js v1.1.0

Table store use state in localStorage when keepTableState is set to true (default). Allowing to restore user state on page load.
Saved state are: 
- Page number;
- Query search;
- Sorting;
- items per page;

Modify table.html template in order to use 'alt' key while changing page to move up / down a complete range. 