### PR TITLE
Add Session management and CSRF attack protection

### DIFF
--- a/app-test/basic/view.php
+++ b/app-test/basic/view.php
@@ -15,14 +15,19 @@ View::addTo(Ui::layout())->setTextContent('Test View Method');
 
 // Test View method
 
-// add Outside view to the grid.
-$view = View::addTo(Ui::layout())->setTextContent('View Text');
+View::addTo(Ui::layout())->setTextContent('Output should not have p4 in class.');
+
+$view = (new View())->setTextContent('View Text');
 $view->appendTailwinds(['m-6', 'p-4', 'w-1/2']);
 $view->appendCssClasses('test');
 $view->removeTailwind('p-4');
-$view->setTextContent('div text <b>content</b>', false);
-View::addTo($view)->setTextContent('paragraph text')->setHtmlTag('p');
 
 $tView = View::addTo(Ui::layout());
 Fohn::styleAs(Base::CONSOLE, [$tView]);
 $tView->setTextContent($view->getHtml());
+
+// display sanitize content.
+View::addTo(Ui::layout())->setTextContent('Output sanitized <b>content</b>.')->setHtmlTag('p');
+
+// display as html content.
+View::addTo(Ui::layout())->setTextContent('Ouput un-sanitize <b>content</b>', false);

--- a/app-test/form/form-control.php
+++ b/app-test/form/form-control.php
@@ -58,9 +58,7 @@ $form = Form::addTo(
     ]
 );
 
-foreach ($controls as $control) {
-    $form->addControl($control);
-}
+$form->addControls($controls);
 
 /** @var Form\Control\Select $countrySelect */
 $countrySelect = $form->getControl('country');

--- a/app-test/index.php
+++ b/app-test/index.php
@@ -12,4 +12,4 @@ require_once __DIR__ . '/init-ui.php';
 
 Header::addTo(Ui::layout(), ['title' => 'Fohn Ui Test', 'size' => 4]);
 
-View::addTo(Ui::layout())->setTextContent('Testing application for Fohn-Ui views and componnents.');
+View::addTo(Ui::layout())->setTextContent('Testing application for Fohn-Ui views and components.');

--- a/app-test/init-ui.php
+++ b/app-test/init-ui.php
@@ -29,6 +29,8 @@ Ui::service()->boot(function (Ui $ui) {
     $ui->setExceptionHandler(PageException::factory());
     // Set demos page.
     $ui->initAppPage(AppTest::createPage($ui->environment));
+
+    $ui->page()->csfrProtect('my secret phrase', '/app-test/index.php');
 });
 
 // Check for coverage

--- a/app-test/interactive/modal.php
+++ b/app-test/interactive/modal.php
@@ -92,11 +92,12 @@ Button::addTo($bar, ['label' => 'Italy', 'color' => 'info', 'type' => 'outline',
 Button::addTo($bar, ['label' => 'Norway', 'color' => 'info', 'type' => 'outline', 'shape' => 'normal'])->appendHtmlAttribute('data-name', 'Norway');
 Button::addTo($bar, ['label' => 'Sweden', 'color' => 'info', 'type' => 'outline', 'shape' => 'normal'])->appendHtmlAttribute('data-name', 'Sweden');
 
-Jquery::jqCallback($bar, 'click', function ($j, $payload) use ($modalForm, $modelCtrl) {
+$fx = Jquery::jqCallback($bar, 'click', function ($j, $payload) use ($modalForm, $modelCtrl) {
     $id = $modelCtrl->getModel()->tryLoadBy('name', $payload['name'])->get('id');
 
     return JsStatements::with($modalForm->jsOpenWithId(Js::var((string) $id)));
 }, ['name' => Jquery::withThis()->data('name')], '.fohn-btn');
+$fx->execute(Js::from("console.log(jQuery(this).data('name'))"));
 
 // / Dynamic
 
@@ -139,8 +140,7 @@ $form->onSubmit(function ($f, $id) use ($modalFieldTest) {
 });
 
 $bar2 = View::addTo(Ui::layout())->appendTailwinds(['inline-block, my-4']);
-Button::addTo($bar2, ['label' => 'Field Test', 'color' => 'info', 'type' => 'outline', 'shape' => 'normal'])
-    ->appendHtmlAttribute('data-name', 'Italy');
+Button::addTo($bar2, ['label' => 'Form Overflow', 'color' => 'info', 'type' => 'outline', 'shape' => 'large']);
 
 Jquery::jqCallback($bar2, 'click', function ($j, $payload) use ($modalFieldTest) {
     return JsStatements::with($modalFieldTest->jsOpenWithId(Js::var('')));

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "phpstan/phpstan": "^1.0",
     "phpstan/phpstan-deprecation-rules": "^1.0",
     "phpunit/phpcov": "*",
-    "phpunit/phpunit": "^9.5.5",
+    "phpunit/phpunit": "^9.6",
     "symfony/process": "^4.4 || ^5.0"
   },
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae341fc778d69812ee1bf64848fa527c",
+    "content-hash": "632ba00e74cd5e85e462e6f9de76319c",
     "packages": [
         {
             "name": "atk4/core",
@@ -3442,16 +3442,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.7",
+            "version": "9.6.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2"
+                "reference": "a9aceaf20a682aeacf28d582654a1670d8826778"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
-                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a9aceaf20a682aeacf28d582654a1670d8826778",
+                "reference": "a9aceaf20a682aeacf28d582654a1670d8826778",
                 "shasum": ""
             },
             "require": {
@@ -3525,7 +3525,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.7"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.9"
             },
             "funding": [
                 {
@@ -3541,7 +3541,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-14T08:58:40+00:00"
+            "time": "2023-06-11T06:13:56+00:00"
         },
         {
             "name": "psr/container",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,11 +15,6 @@
             <directory>tests/Javascript</directory>
         </testsuite>
     </testsuites>
-    <groups>
-        <exclude>
-            <group>demos_http</group>
-        </exclude>
-    </groups>
     <listeners>
         <listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener" />
     </listeners>

--- a/src/Callback/Ajax.php
+++ b/src/Callback/Ajax.php
@@ -8,18 +8,24 @@ declare(strict_types=1);
 
 namespace Fohn\Ui\Callback;
 
-class Ajax extends Request
+class Ajax extends Request implements GuardInterface
 {
     protected string $type = self::AJAX_TYPE;
 
     public function onAjaxPostRequest(\Closure $fx): self
     {
         $this->execute(function () use ($fx) {
+            $this->verifyCSRF();
             $response = $fx($this->getPostRequestPayload());
 
             $this->terminateJson(['jsRendered' => $response->jsRender()]);
         });
 
         return $this;
+    }
+
+    public function verifyCSRF(): void
+    {
+        $this->assertSafeRequest();
     }
 }

--- a/src/Callback/Data.php
+++ b/src/Callback/Data.php
@@ -8,18 +8,24 @@ declare(strict_types=1);
 
 namespace Fohn\Ui\Callback;
 
-class Data extends Request
+class Data extends Request implements GuardInterface
 {
     protected string $type = self::DATA_TYPE;
 
     public function onDataRequest(\Closure $fx): self
     {
         $this->execute(function () use ($fx) {
+            $this->verifyCSRF();
             $data = $fx($this->getPostRequestPayload());
 
             $this->terminateJson(['count' => count($data), 'results' => $data]);
         });
 
         return $this;
+    }
+
+    public function verifyCSRF(): void
+    {
+        $this->assertSafeRequest();
     }
 }

--- a/src/Callback/GuardInterface.php
+++ b/src/Callback/GuardInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types = 1);
+/**
+ * Guard
+ */
+
+namespace Fohn\Ui\Callback;
+
+interface GuardInterface
+{
+    /**
+     * Verify request against csrf attack.
+     */
+    public function verifyCSRF(): void;
+}

--- a/src/Callback/GuardInterface.php
+++ b/src/Callback/GuardInterface.php
@@ -1,8 +1,8 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 /**
- * Guard
+ * Guard.
  */
 
 namespace Fohn\Ui\Callback;

--- a/src/Callback/JqReload.php
+++ b/src/Callback/JqReload.php
@@ -11,7 +11,7 @@ namespace Fohn\Ui\Callback;
 use Fohn\Ui\Js;
 use Fohn\Ui\Js\JsRenderInterface;
 
-class JqReload extends Jquery
+class JqReload extends Jquery implements GuardInterface
 {
     /** Javascript to execute after reload is complete and onSuccess is executed. */
     private ?JsRenderInterface $afterSuccess = null;
@@ -34,12 +34,18 @@ class JqReload extends Jquery
         $this->requestPayload = $requestPayload;
 
         $this->execute(function () use ($fx) {
+            $this->verifyCSRF();
             $response = $fx($this->getPostRequestPayload());
 
             $this->terminateJson($this->getOwner()->renderToJsonArr());
         });
 
         return $this;
+    }
+
+    public function verifyCSRF(): void
+    {
+        $this->assertSafeRequest();
     }
 
     public function jsRender(): string

--- a/src/Callback/Jquery.php
+++ b/src/Callback/Jquery.php
@@ -9,7 +9,7 @@ namespace Fohn\Ui\Callback;
 use Fohn\Ui\Js;
 use Fohn\Ui\Js\JsRenderInterface;
 
-class Jquery extends Request implements JsRenderInterface
+class Jquery extends Request implements JsRenderInterface, GuardInterface
 {
     protected string $type = self::JQUERY_TYPE;
 
@@ -20,8 +20,6 @@ class Jquery extends Request implements JsRenderInterface
     /** Text to display as a confirmation. Set with setConfirm(..). */
     public ?string $confirm = null;
 
-    // TODO confirm for axios
-    /** Use this . */
     public array $apiConfig = [];
 
     /** Include web storage data item (key) value to be include in the request. */
@@ -46,12 +44,18 @@ class Jquery extends Request implements JsRenderInterface
         $this->requestPayload = $requestPayload;
 
         $this->execute(function () use ($fx) {
+            $this->verifyCSRF();
             $response = $fx($this->getPostRequestPayload());
 
             $this->terminateJson(['jsRendered' => $response->jsRender()]);
         });
 
         return $this;
+    }
+
+    public function verifyCSRF(): void
+    {
+        $this->assertSafeRequest();
     }
 
     public function jsRender(): string

--- a/src/Callback/Request.php
+++ b/src/Callback/Request.php
@@ -24,6 +24,10 @@ class Request extends AbstractView
     public const GENERIC_TYPE = '__cb';
     public const SERVER_EVENT_TYPE = '__sse';
 
+    /** Redirect url if csfr verification fail. */
+    private static ?string $csfrRedirectUrl = null;
+    private static bool $guard = false;
+
     protected string $type = self::GENERIC_TYPE;
 
     /** Specify a custom GET trigger. */
@@ -35,6 +39,12 @@ class Request extends AbstractView
     public static function getRunningCallbackArgs(): array
     {
         return static::$runningCallbackArgs;
+    }
+
+    public static function protect(string $redirectUrl = null): void
+    {
+        self::$guard = true;
+        self::$csfrRedirectUrl = $redirectUrl;
     }
 
     /**
@@ -78,6 +88,23 @@ class Request extends AbstractView
         }
 
         return null;
+    }
+
+    protected function assertSafeRequest(): void
+    {
+        if (!self::$guard) {
+            return;
+        }
+
+        $requestToken = Ui::service()->serverRequest()->getHeaderLine('X-CSFR-TOKEN');
+        $saveToken = Ui::session()->get(Ui::TOKEN_KEY_NAME);
+
+        if (!$requestToken || ($requestToken !== $saveToken)) {
+            if (self::$csfrRedirectUrl) {
+                $this->terminateJson(['success' => true, 'jsRendered' => Ui::jsRedirect(self::$csfrRedirectUrl)->jsRender()]);
+            }
+            throw new Exception('Access denied.');
+        }
     }
 
     /**

--- a/src/Callback/Request.php
+++ b/src/Callback/Request.php
@@ -103,6 +103,7 @@ class Request extends AbstractView
             if (self::$csfrRedirectUrl) {
                 $this->terminateJson(['success' => true, 'jsRendered' => Ui::jsRedirect(self::$csfrRedirectUrl)->jsRender()]);
             }
+
             throw new Exception('Access denied.');
         }
     }

--- a/src/Callback/Request.php
+++ b/src/Callback/Request.php
@@ -132,7 +132,7 @@ class Request extends AbstractView
 
     protected function getPostRequestPayload(): array
     {
-        return json_decode(file_get_contents('php://input'), true) ?? [];
+        return Ui::service()->getInput();
     }
 
     /**

--- a/src/Component/Form.php
+++ b/src/Component/Form.php
@@ -296,11 +296,7 @@ class Form extends View implements VueInterface
     private function setControlsWithPostValue(array $payload): void
     {
         foreach ($this->getControls() as $controlName => $control) {
-            $controlPostValue = $payload[$controlName] ?? null;
-            if ($controlPostValue && $control->needSanitize()) {
-                $controlPostValue = Ui::service()->sanitize($controlPostValue);
-            }
-            $control->setWithPostValue($controlPostValue);
+            $control->setWithPostValue($control->sanitize($payload[$controlName] ?? null));
             if ($errorMsg = $control->validate()) {
                 $this->addValidationError($controlName, $errorMsg);
             }

--- a/src/Component/Form.php
+++ b/src/Component/Form.php
@@ -304,7 +304,11 @@ class Form extends View implements VueInterface
     private function setControlsWithPostValue(array $payload): void
     {
         foreach ($this->getControls() as $controlName => $control) {
-            $control->setWithPostValue($payload[$controlName] ?? null);
+            $controlPostValue = $payload[$controlName] ?? null;
+            if ($controlPostValue && $control->needSanitize()) {
+                $controlPostValue = Ui::service()->sanitize($controlPostValue);
+            }
+            $control->setWithPostValue($controlPostValue);
             if ($errorMsg = $control->validate()) {
                 $this->addValidationError($controlName, $errorMsg);
             }

--- a/src/Component/Form.php
+++ b/src/Component/Form.php
@@ -81,13 +81,6 @@ class Form extends View implements VueInterface
         $this->valuesCb = Data::addAbstractTo($this);
     }
 
-    protected function initValueCallback(): void
-    {
-        if (!$this->valuesCb) {
-            $this->valuesCb = Data::addAbstractTo($this);
-        }
-    }
-
     /**
      * Get unique form identifier.
      * Use this identifier for element outside this form
@@ -107,7 +100,6 @@ class Form extends View implements VueInterface
      */
     public function onControlsValueRequest(\Closure $fx): self
     {
-        //        $this->initValueCallback();
         $this->onHooks(self::HOOKS_GET_VALUES, $fx);
 
         $this->valuesCb->onDataRequest(function (array $payload = []): array {

--- a/src/Component/Form/Control.php
+++ b/src/Component/Form/Control.php
@@ -7,6 +7,7 @@ namespace Fohn\Ui\Component\Form;
 use Fohn\Ui\Component\VueInterface;
 use Fohn\Ui\Component\VueTrait;
 use Fohn\Ui\Js\JsFunction;
+use Fohn\Ui\Service\Ui;
 use Fohn\Ui\View;
 
 /**

--- a/src/Component/Form/Control.php
+++ b/src/Component/Form/Control.php
@@ -7,7 +7,6 @@ namespace Fohn\Ui\Component\Form;
 use Fohn\Ui\Component\VueInterface;
 use Fohn\Ui\Component\VueTrait;
 use Fohn\Ui\Js\JsFunction;
-use Fohn\Ui\Service\Ui;
 use Fohn\Ui\View;
 
 /**

--- a/src/Component/Form/Control/Input.php
+++ b/src/Component/Form/Control/Input.php
@@ -26,6 +26,8 @@ class Input extends Control
     protected bool $isDisabled = false;
     protected bool $isReadonly = false;
 
+    protected bool $sanitizePostValue = true;
+
     public ?Tw $inputTws = null;
     public array $inputDefaultTws = [
         'mt-1',
@@ -63,6 +65,11 @@ class Input extends Control
         }
 
         $this->inputTws = $this->inputTws->merge($this->inputDefaultTws);
+    }
+
+    public function needSanitize(): bool
+    {
+        return $this->sanitizePostValue;
     }
 
     public function getCaption(): string

--- a/src/Component/Form/Control/Input.php
+++ b/src/Component/Form/Control/Input.php
@@ -7,6 +7,7 @@ namespace Fohn\Ui\Component\Form\Control;
 use Fohn\Ui\Component\Form\Control;
 use Fohn\Ui\Js\Js;
 use Fohn\Ui\Js\Type\Type;
+use Fohn\Ui\Service\Ui;
 use Fohn\Ui\Tailwind\Tw;
 
 /**
@@ -67,9 +68,9 @@ class Input extends Control
         $this->inputTws = $this->inputTws->merge($this->inputDefaultTws);
     }
 
-    public function needSanitize(): bool
+    public function sanitize(?string $value): ?string
     {
-        return $this->sanitizePostValue;
+        return ($value && $this->sanitizePostValue) ? Ui::service()->sanitize($value) : $value;
     }
 
     public function getCaption(): string

--- a/src/Core/Utils.php
+++ b/src/Core/Utils.php
@@ -100,6 +100,11 @@ class Utils
         return $arguments + $injection;
     }
 
+    public static function generateToken(string $secret, int $strength = 16): string
+    {
+        return bin2hex($secret . '.' . random_bytes($strength));
+    }
+
     public static function decodeJson(string $json, bool $isAssociative = true): array
     {
         $data = json_decode($json, $isAssociative, 512, \JSON_THROW_ON_ERROR);

--- a/src/HtmlTemplate/Value.php
+++ b/src/HtmlTemplate/Value.php
@@ -13,7 +13,7 @@ class Value
 
     private function encodeValueToHtml(string $value): string
     {
-        return Ui::service()->htmlSpecialChars($value);
+        return Ui::service()->sanitize($value);
     }
 
     public function set(string $value): self

--- a/src/Page.php
+++ b/src/Page.php
@@ -30,7 +30,6 @@ class Page extends View
 
     public ?string $toastSelector = '#fohn-toast';
     public string $jsBundleLocation = '/public';
-    private ?string $csfrToken = null;
 
     /** An array of Js packages to include in Page. */
     public array $jsPackages = [

--- a/src/Page.php
+++ b/src/Page.php
@@ -66,12 +66,12 @@ class Page extends View
     /**
      * Protect all callback request, coming from this page, from CSFR attack.
      */
-    public function csfrProtect(string $secret, string $redirectTo = null, int $strenght = 16): void
+    public function csfrProtect(string $secret, string $redirectTo = null, int $strength = 16): void
     {
         Request::protect($redirectTo);
 
         if (!Ui::service()->isAjaxRequest()) {
-            $csfrToken = Utils::generateToken($secret, $strenght);
+            $csfrToken = Utils::generateToken($secret, $strength);
             $this->appendMetaTag(Ui::service()->buildHtmlTag('meta', ['name' => 'csfr-token', 'content' => $csfrToken]));
             Ui::session()->set(static::TOKEN_KEY_NAME, $csfrToken);
         }

--- a/src/Service/Session.php
+++ b/src/Service/Session.php
@@ -137,14 +137,13 @@ class Session implements SessionInterface
 
     protected function closeSession(): void
     {
-        if ($this->hasStatus(PHP_SESSION_ACTIVE)) {
+        if ($this->hasStatus(\PHP_SESSION_ACTIVE)) {
             $status = session_write_close();
 
             if (!$status) {
                 throw new Exception('Unable to close session.');
             }
         }
-
     }
 
     private function hasStatus(int $status): bool

--- a/src/Service/Session.php
+++ b/src/Service/Session.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Session Management.
+ */
+
+namespace Fohn\Ui\Service;
+
+use Fohn\Ui\Core\Exception;
+
+class Session implements SessionInterface
+{
+    protected const READ_ONLY_OPTION = 'read_and_close';
+
+    protected static ?SessionInterface $instance = null;
+
+    private array $sessionOptions = [];
+    private string $namespace = '__fohn_ui';
+
+    final protected function __construct()
+    {
+        // singleton
+    }
+
+    public static function getInstance(): SessionInterface
+    {
+        if (static::$instance === null) {
+            static::$instance = new static();
+        }
+
+        return static::$instance;
+    }
+
+    public function setOptions(array $options): void
+    {
+        $this->sessionOptions = $options;
+    }
+
+    public function set(string $key, string $value, bool $keepOpen = false): void
+    {
+        $this->startSession(array_merge($this->sessionOptions, [self::READ_ONLY_OPTION => false]));
+
+        if (!isset($_SESSION[$this->namespace])) {
+            $_SESSION[$this->namespace] = [];
+        }
+
+        $_SESSION[$this->namespace][$key] = $value;
+
+        if (!$keepOpen) {
+            $this->closeSession();
+        }
+    }
+
+    public function setMultiple(array $values, bool $keepOpen = false): void
+    {
+        foreach ($values as $k => $value) {
+            $this->set($k, $value, true);
+        }
+
+        if (!$keepOpen) {
+            $this->closeSession();
+        }
+    }
+
+    /**
+     * Retrieve a Session key and remove it after.
+     * Will return $default if key is not set.
+     */
+    public function retrieve(string $key, string $default = null): ?string
+    {
+        $value = $this->get($key, $default);
+        $this->forget($key);
+
+        return $value;
+    }
+
+    public function forget(string $key = null): void
+    {
+        $this->startSession();
+        if (!$key && isset($_SESSION[$this->namespace])) {
+            unset($_SESSION[$this->namespace]);
+        }
+        if ($key && isset($_SESSION[$this->namespace]) && isset($_SESSION[$this->namespace][$key])) {
+            unset($_SESSION[$this->namespace][$key]);
+        }
+    }
+
+    public function regenerate(bool $clear = false): bool
+    {
+        $this->startSession($this->sessionOptions);
+
+        return session_regenerate_id($clear);
+    }
+
+    public function get(string $key, string $default = null): ?string
+    {
+        $this->startSession(array_merge($this->sessionOptions, [self::READ_ONLY_OPTION => true]));
+
+        if (!isset($_SESSION[$this->namespace])) {
+            return $default;
+        } elseif (!isset($_SESSION[$this->namespace][$key])) {
+            return $default;
+        }
+
+        return $_SESSION[$this->namespace][$key];
+    }
+
+    /**
+     * Get all session key set for this namespace.
+     */
+    public function body(bool $clear = false): array
+    {
+        $body = [];
+        $this->startSession(array_merge($this->sessionOptions, [self::READ_ONLY_OPTION => true]));
+
+        if (!isset($_SESSION[$this->namespace])) {
+            return $body;
+        }
+
+        foreach ($_SESSION[$this->namespace] as $k => $value) {
+            $body[$k] = $value;
+        }
+
+        if ($clear) {
+            unset($_SESSION[$this->namespace]);
+        }
+
+        return $body;
+    }
+
+    public function destroy(): void
+    {
+        $this->startSession([]);
+        $_SESSION = [];
+        $cookieParam = session_get_cookie_params();
+        setcookie(session_name(), '', time() - 86400, $cookieParam['path'], $cookieParam['domain'], $cookieParam['secure'], $cookieParam['httponly']);
+        session_destroy();
+    }
+
+    protected function startSession(array $options = []): void
+    {
+        if (!$this->hasStatus(\PHP_SESSION_ACTIVE)) {
+            $status = session_start($options);
+
+            if (!$status) {
+                throw new Exception('Unable to start session.');
+            }
+        }
+    }
+
+    protected function closeSession(): void
+    {
+        $status = session_write_close();
+
+        if (!$status) {
+            throw new Exception('Unable to close session.');
+        }
+    }
+
+    private function hasStatus(int $status): bool
+    {
+        return session_status() === $status;
+    }
+}

--- a/src/Service/SessionInterface.php
+++ b/src/Service/SessionInterface.php
@@ -9,8 +9,7 @@ namespace Fohn\Ui\Service;
 
 interface SessionInterface
 {
-
-    public static function getInstance(): SessionInterface;
+    public static function getInstance(): self;
 
     /**
      * Set session option.

--- a/src/Service/SessionInterface.php
+++ b/src/Service/SessionInterface.php
@@ -9,6 +9,9 @@ namespace Fohn\Ui\Service;
 
 interface SessionInterface
 {
+
+    public static function getInstance(): SessionInterface;
+
     /**
      * Set session option.
      */

--- a/src/Service/SessionInterface.php
+++ b/src/Service/SessionInterface.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 /**
  * Session Interface.
+ * @method getInstance()
  */
 
 namespace Fohn\Ui\Service;

--- a/src/Service/SessionInterface.php
+++ b/src/Service/SessionInterface.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 /**
  * Session Interface.
- * @method getInstance()
  */
 
 namespace Fohn\Ui\Service;

--- a/src/Service/SessionInterface.php
+++ b/src/Service/SessionInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Session Interface.
+ */
+
+namespace Fohn\Ui\Service;
+
+interface SessionInterface
+{
+    /**
+     * Set session option.
+     */
+    public function setOptions(array $options): void;
+
+    public function set(string $key, string $value, bool $keepOpen = false): void;
+
+    public function setMultiple(array $values, bool $keepOpen = false): void;
+
+    public function retrieve(string $key, string $default = null): ?string;
+
+    public function forget(string $key = null): void;
+
+    public function get(string $key, string $default = null): ?string;
+
+    public function body(bool $clear = false): array;
+
+    public function destroy(): void;
+}

--- a/src/Service/SessionInterface.php
+++ b/src/Service/SessionInterface.php
@@ -9,24 +9,33 @@ namespace Fohn\Ui\Service;
 
 interface SessionInterface
 {
-    public static function getInstance(): self;
-
     /**
      * Set session option.
      */
     public function setOptions(array $options): void;
 
+    public function get(string $key, string $default = null): ?string;
+
     public function set(string $key, string $value, bool $keepOpen = false): void;
 
     public function setMultiple(array $values, bool $keepOpen = false): void;
 
+    /**
+     * Retrieve a key and remove it from body.
+     */
     public function retrieve(string $key, string $default = null): ?string;
 
+    /**
+     * Remove a key from body.
+     */
     public function forget(string $key = null): void;
 
-    public function get(string $key, string $default = null): ?string;
-
+    /**
+     * Retrieve all key from Session.
+     */
     public function body(bool $clear = false): array;
 
     public function destroy(): void;
+
+    public function regenerate(bool $clear = false): bool;
 }

--- a/src/Service/Ui.php
+++ b/src/Service/Ui.php
@@ -45,6 +45,8 @@ class Ui implements UiInterface
     public const PROD_ENV = 'production';
     public const TEST_ENV = 'test';
 
+    public const TOKEN_KEY_NAME = '_csfr_token';
+
     /** AJAX custom header key-pair value as set in apiService. */
     public const AJAX_HEADER_KEY = 'x-custom-header';
     public const AJAX_HEADER_VALUE = '__fohn-ajax-request';
@@ -62,6 +64,7 @@ class Ui implements UiInterface
     public string $templateEngineClass = HtmlTemplate::class;
     public string $rendererClass = ViewRenderer::class;
     public array $formLayoutSeed = [Standard::class];
+    public string $sessionServiceClass = Session::class;
 
     public string $timezone = 'UTC';
     public string $locale = 'en_CA';
@@ -83,7 +86,10 @@ class Ui implements UiInterface
 
     final private function __construct()
     {
-        $this->templateDirectories[] = dirname(__DIR__, 2) . \DIRECTORY_SEPARATOR . 'template' . \DIRECTORY_SEPARATOR . 'tailwind';
+        $this->templateDirectories[] = dirname(
+            __DIR__,
+            2
+        ) . \DIRECTORY_SEPARATOR . 'template' . \DIRECTORY_SEPARATOR . 'tailwind';
     }
 
     public static function service(): self
@@ -94,6 +100,14 @@ class Ui implements UiInterface
         }
 
         return static::$instance;
+    }
+
+    public static function session(): SessionInterface
+    {
+        /** @var SessionInterface $class */
+        $class = static::service()->sessionServiceClass;
+
+        return $class::getInstance();
     }
 
     public static function getDisplayFormat(string $name): string
@@ -166,8 +180,9 @@ class Ui implements UiInterface
             throw new Exception('Trying to factory from seed but $seed[0] is not set.');
         }
         if (!is_string($seed[0])) {
-            throw (new Exception('Trying to factory from seed but $seed[0] is not a class name (string).'))
-                ->addMoreInfo('$seed[0]', $seed[0]);
+            throw (new Exception(
+                'Trying to factory from seed but $seed[0] is not a class name (string).'
+            ))->addMoreInfo('$seed[0]', $seed[0]);
         }
 
         $className = $seed[0];

--- a/src/Service/Ui.php
+++ b/src/Service/Ui.php
@@ -76,6 +76,9 @@ class Ui implements UiInterface
         'datetime' => 'M d, Y H:i:s',
     ];
 
+    /** The current session. */
+    protected ?SessionInterface $session = null;
+
     /** The top view of the app. */
     private Page $page;
     private App $app;
@@ -102,12 +105,17 @@ class Ui implements UiInterface
         return static::$instance;
     }
 
+    protected function setSession(SessionInterface $session): void
+    {
+        $this->session = $session;
+    }
     public static function session(): SessionInterface
     {
-        /** @var SessionInterface $class */
-        $class = static::service()->sessionServiceClass;
+        if (!self::service()->session) {
+            self::service()->setSession(new (static::service()->sessionServiceClass));
+        }
 
-        return $class::getInstance();
+        return self::service()->session;
     }
 
     public static function getDisplayFormat(string $name): string

--- a/src/Service/Ui.php
+++ b/src/Service/Ui.php
@@ -289,6 +289,11 @@ class Ui implements UiInterface
         return htmlspecialchars($html, \ENT_NOQUOTES | \ENT_HTML5, 'UTF-8');
     }
 
+    public function getInput(): array
+    {
+        return json_decode(file_get_contents('php://input'), true) ?? [];
+    }
+
     /**
      * @param string|array $tag
      * @param string|array $attributes

--- a/src/Service/Ui.php
+++ b/src/Service/Ui.php
@@ -109,6 +109,7 @@ class Ui implements UiInterface
     {
         $this->session = $session;
     }
+
     public static function session(): SessionInterface
     {
         if (!self::service()->session) {

--- a/src/Service/Ui.php
+++ b/src/Service/Ui.php
@@ -104,7 +104,7 @@ class Ui implements UiInterface
 
     public static function session(): SessionInterface
     {
-        /** @var Session $class */
+        /** @var SessionInterface $class */
         $class = static::service()->sessionServiceClass;
 
         return $class::getInstance();

--- a/src/Service/Ui.php
+++ b/src/Service/Ui.php
@@ -104,7 +104,7 @@ class Ui implements UiInterface
 
     public static function session(): SessionInterface
     {
-        /** @var SessionInterface $class */
+        /** @var Session $class */
         $class = static::service()->sessionServiceClass;
 
         return $class::getInstance();

--- a/src/Service/Ui.php
+++ b/src/Service/Ui.php
@@ -284,7 +284,7 @@ class Ui implements UiInterface
         return Utils::generateId($viewName, $keep, $lenght);
     }
 
-    public function htmlSpecialChars(string $html): string
+    public function sanitize(string $html): string
     {
         return htmlspecialchars($html, \ENT_NOQUOTES | \ENT_HTML5, 'UTF-8');
     }

--- a/src/Service/UiInterface.php
+++ b/src/Service/UiInterface.php
@@ -92,6 +92,9 @@ interface UiInterface
     /** Return a Form Layout Interface. Called by Form for its default layout. */
     public function getFormLayout(): FormLayoutInterface;
 
+    /** Return request php/input content as array. */
+    public function getInput(): array;
+
     /**
      * Generate Html tag.
      *

--- a/src/Service/UiInterface.php
+++ b/src/Service/UiInterface.php
@@ -34,6 +34,8 @@ interface UiInterface
 
     public static function theme(): ThemeInterface;
 
+    public static function session(): SessionInterface;
+
     public static function page(): Page;
 
     public static function serverRequest(): ServerRequestInterface;

--- a/src/Service/UiInterface.php
+++ b/src/Service/UiInterface.php
@@ -87,7 +87,7 @@ interface UiInterface
     /** Generate View::attributeId property. */
     public function factoryId(string $viewName): string;
 
-    public function htmlSpecialChars(string $html): string;
+    public function sanitize(string $html): string;
 
     /** Return a Form Layout Interface. Called by Form for its default layout. */
     public function getFormLayout(): FormLayoutInterface;

--- a/src/View.php
+++ b/src/View.php
@@ -161,9 +161,9 @@ class View extends AbstractView
      * In order to use html markup, $useHtmlSpecialChars needs to be false.
      * textContent is set in template at rendering if set.
      */
-    public function setTextContent(?string $text, bool $useHtmlSepcialChars = true): self
+    public function setTextContent(?string $text, bool $sanitize = true): self
     {
-        $this->textContent = ($text && $useHtmlSepcialChars) ? Ui::service()->htmlSpecialChars($text) : $text;
+        $this->textContent = ($text && $sanitize) ? Ui::service()->sanitize($text) : $text;
 
         return $this;
     }

--- a/template/tailwind/page.html
+++ b/template/tailwind/page.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
 <html lang="{lang}en{/}" class="">
   <head>
-    <title>{title}Fohn UI - Untitled Project{/}</title>{$meta}
+    <title>{title}Fohn UI - Untitled Project{/}</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {$meta}
     {$head}
     {$includeHeadJs}
     {$includeCss}

--- a/template/tailwind/vue-component/form/control/password.html
+++ b/template/tailwind/vue-component/form/control/password.html
@@ -16,7 +16,7 @@
                         class="{$inputTws}"
                         :class="@{'border-red-900': errorMsg, 'bg-red-100': errorMsg, 'text-gray-400': inputAttrs.disabled}"
                 >
-                <div class="absolute items-right px-2 right-2 bg-white cursor-pointer">
+                <div class="absolute items-right px-2 right-2 bg-transparent cursor-pointer">
                     <div class="grid grid-cols-1 gap-2">
                         <div><i :class="@{'bi bi-eye-fill': inputAttrs.type === 'password', 'bi bi-eye-slash-fill': inputAttrs.type === 'text'}" @click="toggleType('text')"></i></div>
                     </div>

--- a/tests/Session/MockSession.php
+++ b/tests/Session/MockSession.php
@@ -1,16 +1,15 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Fohn\Ui\Tests\Session;
 
-use Fohn\Ui\Core\Exception;
 use Fohn\Ui\Service\Session;
 
 class MockSession extends Session
 {
-
     public string $namespace = '__fohn_ui';
+
     public function __construct()
     {
         $_SESSION = [];
@@ -19,5 +18,4 @@ class MockSession extends Session
     protected function startSession(array $options = []): void
     {
     }
-
 }

--- a/tests/Session/MockSession.php
+++ b/tests/Session/MockSession.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Fohn\Ui\Tests\Session;
+
+use Fohn\Ui\Core\Exception;
+use Fohn\Ui\Service\Session;
+
+class MockSession extends Session
+{
+
+    public string $namespace = '__fohn_ui';
+    public function __construct()
+    {
+        $_SESSION = [];
+    }
+
+    protected function startSession(array $options = []): void
+    {
+    }
+
+}

--- a/tests/Session/SessionTest.php
+++ b/tests/Session/SessionTest.php
@@ -1,19 +1,14 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 /**
  * Session test.
- *
  */
 
 namespace Fohn\Ui\Tests\Session;
 
-use Fohn\Ui\App;
-use Fohn\Ui\Service\Session;
-
 class SessionTest extends \PHPUnit\Framework\TestCase
 {
-
     public function testNamespace(): void
     {
         $session = new MockSession();
@@ -28,9 +23,9 @@ class SessionTest extends \PHPUnit\Framework\TestCase
 
         $session->set('k', 'v', false);
         $this->assertSame('v', $session->get('k'));
-        $this->assertSame($_SESSION[$session->namespace]['k'], 'v' );
+        $this->assertSame($_SESSION[$session->namespace]['k'], 'v');
 
-        $this->assertSame(null, $session->get('noKey'));
+        $this->assertNull($session->get('noKey'));
         $this->assertSame('value', $session->get('noKey', 'value'));
     }
 
@@ -64,6 +59,4 @@ class SessionTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('v', $session->retrieve('k'));
         $this->assertFalse(isset($_SESSION[$session->namespace]['k']));
     }
-
 }
-

--- a/tests/Session/SessionTest.php
+++ b/tests/Session/SessionTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types = 1);
+/**
+ * Session test.
+ *
+ */
+
+namespace Fohn\Ui\Tests\Session;
+
+use Fohn\Ui\App;
+use Fohn\Ui\Service\Session;
+
+class SessionTest extends \PHPUnit\Framework\TestCase
+{
+
+    public function testNamespace(): void
+    {
+        $session = new MockSession();
+        $session->set('k', 'v', false);
+
+        $this->assertTrue(isset($_SESSION[$session->namespace]));
+    }
+
+    public function testSetGet(): void
+    {
+        $session = new MockSession();
+
+        $session->set('k', 'v', false);
+        $this->assertSame('v', $session->get('k'));
+        $this->assertSame($_SESSION[$session->namespace]['k'], 'v' );
+
+        $this->assertSame(null, $session->get('noKey'));
+        $this->assertSame('value', $session->get('noKey', 'value'));
+    }
+
+    public function testSetMultiple(): void
+    {
+        $session = new MockSession();
+        $values = ['k1' => 'v1', 'k2' => 'v2', 'k3' => 'v3'];
+        $session->setMultiple($values);
+
+        $this->assertSame('v2', $session->get('k2'));
+        $this->assertSame($values, $session->body());
+    }
+
+    public function testForget(): void
+    {
+        $session = new MockSession();
+
+        $session->set('k1', 'v1');
+        $session->set('k2', 'v2');
+        $session->forget('k2');
+        $this->assertSame(['k1' => 'v1'], $session->body(true));
+        $this->assertSame([], $_SESSION);
+    }
+
+    public function testRetrieve(): void
+    {
+        $session = new MockSession();
+
+        $session->set('k', 'v');
+
+        $this->assertSame('v', $session->retrieve('k'));
+        $this->assertFalse(isset($_SESSION[$session->namespace]['k']));
+    }
+
+}
+


### PR DESCRIPTION
## Add csfr protection to callback.

Add it from your page:

```
$page->csfrProtect('my secret phrase', '/');
```
Then, each callback that implement GuardInterface will be protect from csfr attack when fire from this $page.

## Sanitize input by default

Form inputs are sanitized by default.


Required fohn-ui.js version 1.3 and higher

