### PR TITLE
Add table action button

### DIFF
--- a/app-test/collection/table-as-crud.php
+++ b/app-test/collection/table-as-crud.php
@@ -39,6 +39,16 @@ $grid = View::addTo(Ui::layout(), ['template' => Ui::templateFromFile(
 $table = Table::addTo($grid);
 $table->setCaption(AppTest::tableCaptionFactory('Countries'));
 
+$actionDelete = (new Table\Action(['reloadTable' => true]))->setTrigger(Button::factory(['label' => 'do some', 'color' => 'neutral']));
+$table->addTableAction($actionDelete)->onTrigger(function ($ids) {
+    return JsStatements::with([JsToast::success('Delete Action! ' . implode(' / ', $ids))]);
+});
+
+$actionTest = (new Table\Action(['keepSelection' => true]))->setTrigger(Button::factory(['label' => 'do test', 'color' => 'neutral']));
+$table->addTableAction($actionTest)->onTrigger(function ($ids) {
+    return JsStatements::with([JsToast::success('Test Action! ' . implode(' / ', $ids))]);
+});
+
 $editDialog = Modal\AsForm::addTo(Ui::layout(), ['title' => 'Edit Country']);
 $deleteDialog = Modal\AsDialog::addTo(Ui::layout(), ['title' => 'Confirm country deletion:']);
 

--- a/app-test/collection/table-as-crud.php
+++ b/app-test/collection/table-as-crud.php
@@ -36,17 +36,17 @@ $grid = View::addTo(Ui::layout(), ['template' => Ui::templateFromFile(
     dirname(__DIR__) . '/templates/split-columns.html'
 )]);
 
-$table = Table::addTo($grid);
+$table = Table::addTo($grid, ['keepSelectionAcrossPage' => true]);
 $table->setCaption(AppTest::tableCaptionFactory('Countries'));
 
 $actionDelete = (new Table\Action(['reloadTable' => true]))->setTrigger(Button::factory(['label' => 'Delete', 'color' => 'neutral']));
-$table->addTableAction($actionDelete)->onTrigger(function ($ids) {
+$table->addRowsAction($actionDelete)->onTrigger(function ($ids) {
     // performs deletes on ids
     return JsStatements::with([JsToast::success('Delete Action! ' . implode(' / ', $ids))]);
 });
 
-$actionTest = (new Table\Action(['keepSelection' => true]))->setTrigger(Button::factory(['label' => 'do test', 'color' => 'neutral']));
-$table->addTableAction($actionTest)->onTrigger(function ($ids) {
+$actionTest = (new Table\Action(['keepSelection' => true]))->setTrigger(Button::factory(['label' => 'Sleep', 'color' => 'neutral']));
+$table->addRowsAction($actionTest)->onTrigger(function ($ids) {
     return JsStatements::with([JsToast::success('Test Action! ' . implode(' / ', $ids))]);
 });
 

--- a/app-test/collection/table-as-crud.php
+++ b/app-test/collection/table-as-crud.php
@@ -40,14 +40,21 @@ $table = Table::addTo($grid, ['keepSelectionAcrossPage' => true]);
 $table->setCaption(AppTest::tableCaptionFactory('Countries'));
 
 $actionDelete = (new Table\Action(['reloadTable' => true]))->setTrigger(Button::factory(['label' => 'Delete', 'color' => 'neutral']));
-$table->addRowsAction($actionDelete)->onTrigger(function ($ids) {
+$actionMsg = new Table\Action\Messages();
+$actionMsg->single = 'This action will delete 1 country. Are you sure?';
+$actionMsg->multiple = 'This action will delete {#} countries. Are you sure?';
+
+$actionDelete->addConfirmationDialog('Delete countries:', $actionMsg);
+$table->addRowsAction($actionDelete)->onTrigger(function ($ids, $dialog) {
     // performs deletes on ids
-    return JsStatements::with([JsToast::success('Delete Action! ' . implode(' / ', $ids))]);
+    return JsStatements::with([JsToast::success('Delete Action! ' . implode(' / ', $ids)), $dialog->jsClose()]);
 });
 
-$actionTest = (new Table\Action(['keepSelection' => true]))->setTrigger(Button::factory(['label' => 'Sleep', 'color' => 'neutral']));
+$actionTest = (new Table\Action(['keepSelection' => true]))->setTrigger(Button::factory(['label' => 'Process', 'color' => 'neutral']));
 $table->addRowsAction($actionTest)->onTrigger(function ($ids) {
-    return JsStatements::with([JsToast::success('Test Action! ' . implode(' / ', $ids))]);
+    sleep(2);
+
+    return JsStatements::with([JsToast::success('Process Action! ' . implode(' / ', $ids))]);
 });
 
 $editDialog = Modal\AsForm::addTo(Ui::layout(), ['title' => 'Edit Country']);

--- a/app-test/collection/table-as-crud.php
+++ b/app-test/collection/table-as-crud.php
@@ -39,8 +39,9 @@ $grid = View::addTo(Ui::layout(), ['template' => Ui::templateFromFile(
 $table = Table::addTo($grid);
 $table->setCaption(AppTest::tableCaptionFactory('Countries'));
 
-$actionDelete = (new Table\Action(['reloadTable' => true]))->setTrigger(Button::factory(['label' => 'do some', 'color' => 'neutral']));
+$actionDelete = (new Table\Action(['reloadTable' => true]))->setTrigger(Button::factory(['label' => 'Delete', 'color' => 'neutral']));
 $table->addTableAction($actionDelete)->onTrigger(function ($ids) {
+    // performs deletes on ids
     return JsStatements::with([JsToast::success('Delete Action! ' . implode(' / ', $ids))]);
 });
 

--- a/app-test/interactive/modal.php
+++ b/app-test/interactive/modal.php
@@ -32,10 +32,7 @@ $msg = Message::addTo($infoDialog, ['title' => 'Note:', 'color' => 'error']);
 $msg->addText(Utils::getLoremIpsum(20));
 
 $btn = Button::addTo(Ui::layout(), ['label' => 'Display Info', 'color' => 'info', 'type' => 'outline']);
-Jquery::addEventTo($btn, 'click')
-    ->executes([
-        $infoDialog->jsOpen(),
-    ]);
+$infoDialog->jsOpenWith($btn);
 
 // // AS DIALOG
 
@@ -50,7 +47,7 @@ $dialog->addConfirmEvent(function (array $payload) use ($dialog) {
 });
 
 $btn = Button::addTo(Ui::layout(), ['label' => 'Open Dialog', 'color' => 'info', 'type' => 'outline']);
-$dialog->jsOpenWith($btn);
+$dialog->jsOpenWith($btn, ['message' => 'Are you sure?']);
 
 // / AS Form
 

--- a/app-test/interactive/modal.php
+++ b/app-test/interactive/modal.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Fohn\Ui\AppTest;
 
+use Fohn\Ui\App;
 use Fohn\Ui\AppTest\Model\Country;
 use Fohn\Ui\AppTest\Model\FieldTest;
 use Fohn\Ui\Component\Form;
@@ -50,6 +51,7 @@ $confirm->onCallbackEvent('cancel', function (array $payload) use ($confirm) {
 
 $confirm->addCallbackEvent('confirm', new Button(['label' => 'Yes', 'type' => 'outline', 'color' => 'success', 'size' => 'small']));
 $confirm->onCallbackEvent('confirm', function (array $payload) use ($confirm) {
+
     return JsStatements::with([
         JsToast::info('All goods!', 'Operation confirm.'),
         $confirm->jsClose(),
@@ -101,7 +103,7 @@ $fx->execute(Js::from("console.log(jQuery(this).data('name'))"));
 
 // / Dynamic
 
-$modalDynamic = Modal::addTo(Ui::layout(), ['title' => 'Load on demand content.']);
+$modalDynamic = Modal\AsDynamic::addTo(Ui::layout(), ['title' => 'Load on demand content.']);
 $modalDynamic->addCloseButton(new Button(['label' => 'Close', 'type' => 'outline', 'color' => 'info', 'size' => 'small']));
 
 $modalDynamic->onOpen(function ($modal) {

--- a/app-test/interactive/modal.php
+++ b/app-test/interactive/modal.php
@@ -39,28 +39,18 @@ Jquery::addEventTo($btn, 'click')
 
 // // AS DIALOG
 
-$confirm = AsDialog::addTo(Ui::layout(), ['title' => 'Confirm this action', 'isClosable' => false]);
+$dialog = AsDialog::addTo(Ui::layout(), ['title' => 'Confirm this action', 'isClosable' => false]);
+$dialog->addCancelEvent();
 
-$confirm->addCallbackEvent('cancel', new Button(['label' => 'No', 'type' => 'outline', 'color' => 'error', 'size' => 'small']));
-$confirm->onCallbackEvent('cancel', function (array $payload) use ($confirm) {
-    return JsStatements::with([
-        $confirm->jsClose(),
-    ]);
-});
-
-$confirm->addCallbackEvent('confirm', new Button(['label' => 'Yes', 'type' => 'outline', 'color' => 'success', 'size' => 'small']));
-$confirm->onCallbackEvent('confirm', function (array $payload) use ($confirm) {
+$dialog->addConfirmEvent(function (array $payload) use ($dialog) {
     return JsStatements::with([
         JsToast::info('All goods!', 'Operation confirm.'),
-        $confirm->jsClose(),
+        $dialog->jsClose(),
     ]);
 });
 
 $btn = Button::addTo(Ui::layout(), ['label' => 'Open Dialog', 'color' => 'info', 'type' => 'outline']);
-Jquery::addEventTo($btn, 'click')
-    ->executes([
-        $confirm->jsOpen(['message' => 'Are you sure ?']),
-    ]);
+$dialog->jsOpenWith($btn);
 
 // / AS Form
 

--- a/app-test/interactive/modal.php
+++ b/app-test/interactive/modal.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Fohn\Ui\AppTest;
 
-use Fohn\Ui\App;
 use Fohn\Ui\AppTest\Model\Country;
 use Fohn\Ui\AppTest\Model\FieldTest;
 use Fohn\Ui\Component\Form;
@@ -51,7 +50,6 @@ $confirm->onCallbackEvent('cancel', function (array $payload) use ($confirm) {
 
 $confirm->addCallbackEvent('confirm', new Button(['label' => 'Yes', 'type' => 'outline', 'color' => 'success', 'size' => 'small']));
 $confirm->onCallbackEvent('confirm', function (array $payload) use ($confirm) {
-
     return JsStatements::with([
         JsToast::info('All goods!', 'Operation confirm.'),
         $confirm->jsClose(),

--- a/src/Callback/Ajax.php
+++ b/src/Callback/Ajax.php
@@ -8,8 +8,6 @@ declare(strict_types=1);
 
 namespace Fohn\Ui\Callback;
 
-use Fohn\Ui\Js\JsRenderInterface;
-
 class Ajax extends Request implements GuardInterface
 {
     protected string $type = self::AJAX_TYPE;

--- a/src/Callback/Ajax.php
+++ b/src/Callback/Ajax.php
@@ -8,17 +8,19 @@ declare(strict_types=1);
 
 namespace Fohn\Ui\Callback;
 
+use Fohn\Ui\Js\JsRenderInterface;
+
 class Ajax extends Request implements GuardInterface
 {
     protected string $type = self::AJAX_TYPE;
 
-    public function onAjaxPostRequest(\Closure $fx): self
+    public function onAjaxPostRequest(\Closure $fx, array $extraOutput = []): self
     {
-        $this->execute(function () use ($fx) {
+        $this->execute(function () use ($fx, $extraOutput) {
             $this->verifyCSRF();
             $response = $fx($this->getPostRequestPayload());
 
-            $this->terminateJson(['jsRendered' => $response->jsRender()]);
+            $this->terminateJson(array_merge(['jsRendered' => $response->jsRender()], $extraOutput));
         });
 
         return $this;

--- a/src/Component/Modal.php
+++ b/src/Component/Modal.php
@@ -48,7 +48,7 @@ class Modal extends View implements VueInterface
     /**
      * Add jQuery event to a View needed to open Modal.
      */
-    public function jsOpenWith(View $view, array $options = ['message' => 'Are you sure ?']): self
+    public function jsOpenWith(View $view, array $options = []): self
     {
         Jquery::addEventTo($view, 'click')
             ->executes([

--- a/src/Component/Modal.php
+++ b/src/Component/Modal.php
@@ -7,7 +7,6 @@ declare(strict_types=1);
 
 namespace Fohn\Ui\Component;
 
-use Fohn\Ui\Callback\Generic;
 use Fohn\Ui\Core\Exception;
 use Fohn\Ui\Js\Js;
 use Fohn\Ui\Js\JsRenderInterface;
@@ -45,8 +44,6 @@ class Modal extends View implements VueInterface
 
     public array $modalTwsWidth = ['w-10/12', 'md:w-4/6', 'lg:w-1/2'];
 
-
-
     public function addCloseButton(Button $closeBtn): self
     {
         $this->addView($closeBtn, 'Buttons');
@@ -57,7 +54,6 @@ class Modal extends View implements VueInterface
 
     public function addContent(View $view, string $region = self::MAIN_TEMPLATE_REGION): View
     {
-
         return $this->addView($view, $region);
     }
 
@@ -91,7 +87,7 @@ class Modal extends View implements VueInterface
     {
         // @phpstan-ignore-next-line
         $js = $this->jsGetStore(self::PINIA_PREFIX)->setTitle($title);
-        $this->content->appendJsAction($js);
+        $this->appendJsAction($js);
 
         return $js;
     }

--- a/src/Component/Modal.php
+++ b/src/Component/Modal.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Fohn\Ui\Component;
 
 use Fohn\Ui\Core\Exception;
+use Fohn\Ui\Js\Jquery;
 use Fohn\Ui\Js\Js;
 use Fohn\Ui\Js\JsRenderInterface;
 use Fohn\Ui\Js\Type\Type;
@@ -44,10 +45,23 @@ class Modal extends View implements VueInterface
 
     public array $modalTwsWidth = ['w-10/12', 'md:w-4/6', 'lg:w-1/2'];
 
+    /**
+     * Add jQuery event to a View needed to open Modal.
+     */
+    public function jsOpenWith(View $view, array $options = ['message' => 'Are you sure ?']): self
+    {
+        Jquery::addEventTo($view, 'click')
+            ->executes([
+                $this->jsOpen($options),
+            ]);
+
+        return $this;
+    }
+
     public function addCloseButton(Button $closeBtn): self
     {
         $this->addView($closeBtn, 'Buttons');
-        static::bindVueEvent($closeBtn, 'click', 'closeModal');
+        static::bindVueEvent($closeBtn, 'click', '() => closeModal(false)');
 
         return $this;
     }

--- a/src/Component/Modal.php
+++ b/src/Component/Modal.php
@@ -113,6 +113,7 @@ class Modal extends View implements VueInterface
         $this->getTemplate()->trySetJs('title', Type::factory($this->title));
         $this->getTemplate()->trySetJs('isClosable', Type::factory($this->isClosable));
 
+        $this->renderEvents();
         $this->createVueApp(self::COMP_NAME, [], $this->getDefaultSelector());
 
         parent::beforeHtmlRender();

--- a/src/Component/Modal.php
+++ b/src/Component/Modal.php
@@ -32,10 +32,7 @@ class Modal extends View implements VueInterface
 
     protected bool $isClosable = true;
 
-    protected ?Generic $cb = null;
-
-    public View $content;
-    public View $remoteContent;
+//    public ?View $content = null;
 
     public array $defaultModalTws = [
         'relative',
@@ -54,8 +51,7 @@ class Modal extends View implements VueInterface
     protected function initRenderTree(): void
     {
         parent::initRenderTree();
-        $this->content = View::addTo($this);
-        $this->remoteContent = View::addTo($this, [], 'remoteContent');
+//        $this->content = View::addTo($this);
     }
 
     public function addCloseButton(Button $closeBtn): self
@@ -66,19 +62,10 @@ class Modal extends View implements VueInterface
         return $this;
     }
 
-    public function onOpen(\Closure $fx): void
+    public function addContent(View $view, string $region = self::MAIN_TEMPLATE_REGION): View
     {
-        $this->cb = Generic::addAbstractTo($this);
 
-        $this->cb->onRequest(function () use ($fx) {
-            $fx($this->remoteContent);
-            $this->cb->terminateJson($this->remoteContent->renderToJsonArr());
-        });
-    }
-
-    public function addContent(View $view): View
-    {
-        return $this->content->addView($view);
+        return $this->addView($view, $region);
     }
 
     /**
@@ -122,9 +109,6 @@ class Modal extends View implements VueInterface
         $this->getTemplate()->trySetJs('storeId', Type::factory($this->getPiniaStoreId(self::PINIA_PREFIX)));
         $this->getTemplate()->trySetJs('title', Type::factory($this->title));
         $this->getTemplate()->trySetJs('isClosable', Type::factory($this->isClosable));
-        if ($this->cb) {
-            $this->getTemplate()->trySetJs('contentUrl', Type::factory($this->cb->getUrl()));
-        }
 
         $this->createVueApp(self::COMP_NAME, [], $this->getDefaultSelector());
 

--- a/src/Component/Modal.php
+++ b/src/Component/Modal.php
@@ -114,6 +114,7 @@ class Modal extends View implements VueInterface
         $this->getTemplate()->trySetJs('isClosable', Type::factory($this->isClosable));
 
         $this->renderEvents();
+        $this->renderProperties();
         $this->createVueApp(self::COMP_NAME, [], $this->getDefaultSelector());
 
         parent::beforeHtmlRender();

--- a/src/Component/Modal.php
+++ b/src/Component/Modal.php
@@ -32,8 +32,6 @@ class Modal extends View implements VueInterface
 
     protected bool $isClosable = true;
 
-//    public ?View $content = null;
-
     public array $defaultModalTws = [
         'relative',
         'top-20',
@@ -47,17 +45,12 @@ class Modal extends View implements VueInterface
 
     public array $modalTwsWidth = ['w-10/12', 'md:w-4/6', 'lg:w-1/2'];
 
-    // w-10/12 md:w-4/6 lg:w-1/2
-    protected function initRenderTree(): void
-    {
-        parent::initRenderTree();
-//        $this->content = View::addTo($this);
-    }
+
 
     public function addCloseButton(Button $closeBtn): self
     {
         $this->addView($closeBtn, 'Buttons');
-        Ui::bindVueEvent($closeBtn, 'click', 'closeModal');
+        static::bindVueEvent($closeBtn, 'click', 'closeModal');
 
         return $this;
     }

--- a/src/Component/Modal/AsDialog.php
+++ b/src/Component/Modal/AsDialog.php
@@ -10,14 +10,12 @@ namespace Fohn\Ui\Component\Modal;
 
 use Fohn\Ui\Callback\Ajax;
 use Fohn\Ui\Component\Modal;
-use Fohn\Ui\Component\VueTrait;
 use Fohn\Ui\Core\HookTrait;
 use Fohn\Ui\Js\JsFunction;
 use Fohn\Ui\Js\JsRenderInterface;
 use Fohn\Ui\Js\Type\ObjectLiteral;
 use Fohn\Ui\Js\Type\StringLiteral;
 use Fohn\Ui\Js\Type\Variable;
-use Fohn\Ui\Service\Ui;
 use Fohn\Ui\View\Button;
 
 class AsDialog extends Modal
@@ -56,10 +54,6 @@ class AsDialog extends Modal
         });
 
         return $this;
-    }
-
-    public function jsSetMessage(string $msg) {
-
     }
 
     protected function beforeHtmlRender(): void

--- a/src/Component/Modal/AsDialog.php
+++ b/src/Component/Modal/AsDialog.php
@@ -23,33 +23,39 @@ class AsDialog extends Modal
     /** @var array<string, Ajax> */
     private array $callbacks = [];
 
-    protected array $cancelButtonSeed = [Button::class, 'label' => 'No', 'type' => 'outline', 'color' => 'error', 'size' => 'small'];
-    protected array $confirmButtonSeed = [Button::class, 'label' => 'Yes', 'type' => 'outline', 'color' => 'success', 'size' => 'small'];
+    public array $cancelButtonSeed = [Button::class, 'label' => 'No', 'type' => 'outline', 'color' => 'error', 'size' => 'small'];
+    public array $confirmButtonSeed = [Button::class, 'label' => 'Yes', 'type' => 'outline', 'color' => 'success', 'size' => 'small'];
 
     /**
      * Add a close event to modal using Closure function.
      * When calling this method with no Closure function, the modal will
      * close without triggering a callback event.
      */
-    public function addCancelEvent(\Closure $fx = null): self
+    public function addCancelEvent(\Closure $fx = null, View $trigger = null): View
     {
+        $cancelTrigger = $trigger ?: View::factoryFromSeed($this->cancelButtonSeed);
         if ($fx) {
-            $this->addCallbackEvent('cancel', View::factoryFromSeed($this->cancelButtonSeed));
+            $this->addCallbackEvent('cancel', $cancelTrigger);
             $this->onCallbackEvent('cancel', $fx);
         } else {
-            $btn = $this->addView(View::factoryFromSeed($this->cancelButtonSeed), 'Buttons');
-            static::bindVueEvent($btn, 'click', 'closeModal(true)');
+            $this->addView($cancelTrigger, 'Buttons');
+            static::bindVueEvent($cancelTrigger, 'click', 'closeModal(true)');
         }
 
-        return $this;
+        return $cancelTrigger;
     }
 
-    public function addConfirmEvent(\Closure $fx): self
+    public function addConfirmEvent(\Closure $fx = null, View $trigger = null): View
     {
-        $this->addCallbackEvent('confirm', View::factoryFromSeed($this->confirmButtonSeed));
-        $this->onCallbackEvent('confirm', $fx);
+        $confirmTrigger = $trigger ?: View::factoryFromSeed($this->confirmButtonSeed);
+        if ($fx) {
+            $this->addCallbackEvent('confirm', $confirmTrigger);
+            $this->onCallbackEvent('confirm', $fx);
+        } else {
+            $this->addView($confirmTrigger, 'Buttons');
+        }
 
-        return $this;
+        return $confirmTrigger;
     }
 
     public function addCallbackEvent(string $name, View $trigger, array $payload = [], string $eventName = 'click'): View

--- a/src/Component/Modal/AsDialog.php
+++ b/src/Component/Modal/AsDialog.php
@@ -57,6 +57,10 @@ class AsDialog extends Modal
         return $this;
     }
 
+    public function jsSetMessage(string $msg) {
+
+    }
+
     protected function beforeHtmlRender(): void
     {
         $renderCallbacks = [];

--- a/src/Component/Modal/AsDialog.php
+++ b/src/Component/Modal/AsDialog.php
@@ -23,8 +23,8 @@ class AsDialog extends Modal
     /** @var array<string, Ajax> */
     private array $callbacks = [];
 
-    public array $cancelButtonSeed = [Button::class, 'label' => 'No', 'type' => 'outline', 'color' => 'error', 'size' => 'small'];
-    public array $confirmButtonSeed = [Button::class, 'label' => 'Yes', 'type' => 'outline', 'color' => 'success', 'size' => 'small'];
+    public array $cancelButtonSeed = [Button::class, 'label' => 'Cancel', 'type' => 'outline', 'color' => 'error', 'size' => 'small'];
+    public array $confirmButtonSeed = [Button::class, 'label' => 'Confirm', 'type' => 'outline', 'color' => 'success', 'size' => 'small'];
 
     /**
      * Add a close event to modal using Closure function.

--- a/src/Component/Modal/AsDialog.php
+++ b/src/Component/Modal/AsDialog.php
@@ -10,6 +10,7 @@ namespace Fohn\Ui\Component\Modal;
 
 use Fohn\Ui\Callback\Ajax;
 use Fohn\Ui\Component\Modal;
+use Fohn\Ui\Component\VueTrait;
 use Fohn\Ui\Core\HookTrait;
 use Fohn\Ui\Js\JsFunction;
 use Fohn\Ui\Js\JsRenderInterface;
@@ -42,7 +43,7 @@ class AsDialog extends Modal
         $this->callbacks[$name] = Ajax::addAbstractTo($this);
         $eventFn = JsFunction::declareFunction('onCallback', [Variable::set('$event'), StringLiteral::set($name), ObjectLiteral::set($payload)]);
         $this->addView($trigger, 'Buttons');
-        Ui::bindVueEvent($trigger, $eventName, $eventFn->jsRender());
+        static::bindVueEvent($trigger, $eventName, $eventFn->jsRender());
 
         return $this;
     }

--- a/src/Component/Modal/AsDynamic.php
+++ b/src/Component/Modal/AsDynamic.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 /**
  * Modal that display content from a callback request.
  */

--- a/src/Component/Modal/AsDynamic.php
+++ b/src/Component/Modal/AsDynamic.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types = 1);
+/**
+ * Modal that display content from a callback request.
+ */
+
+namespace Fohn\Ui\Component\Modal;
+
+use Fohn\Ui\Callback\Generic;
+use Fohn\Ui\Component\Modal;
+use Fohn\Ui\Js\Type\Type;
+use Fohn\Ui\View;
+
+class AsDynamic extends Modal
+{
+    protected ?Generic $cb = null;
+    protected View $dynamicContent;
+
+    protected function initRenderTree(): void
+    {
+        parent::initRenderTree();
+        $this->dynamicContent = View::addTo($this);
+    }
+
+    public function onOpen(\Closure $fx): void
+    {
+        $this->cb = Generic::addAbstractTo($this);
+
+        $this->cb->onRequest(function () use ($fx) {
+            $fx($this->dynamicContent);
+            $this->cb->terminateJson($this->dynamicContent->renderToJsonArr());
+        });
+    }
+
+    protected function beforeHtmlRender(): void
+    {
+        $this->getTemplate()->trySetJs('contentUrl', Type::factory($this->cb->getUrl()));
+
+        parent::beforeHtmlRender();
+    }
+}

--- a/src/Component/Table.php
+++ b/src/Component/Table.php
@@ -40,7 +40,7 @@ class Table extends View implements VueInterface
     use VueTrait;
 
     public const CELL_PROP_NAME = 'cell';
-    public const SELECTABLE_ACTION_REGION = 'selectableActions';
+    public const TABLE_ACTION_REGION = 'tableActions';
 
     public string $defaultTemplate = 'vue-component/table.html';
     protected const HOOKS_DATA_REQUEST = self::class . '@data_request';
@@ -144,7 +144,7 @@ class Table extends View implements VueInterface
     public function addTableAction(Action $action): TriggerCtrl
     {
         $this->hasSelectableRows = true;
-        $this->addView($action, self::SELECTABLE_ACTION_REGION);
+        $this->addView($action, self::TABLE_ACTION_REGION);
 
         return new TriggerCtrl($action);
     }
@@ -304,7 +304,7 @@ class Table extends View implements VueInterface
         $this->getTemplate()->setJs('keepTableState', Js::boolean($this->keepTableState));
         $this->getTemplate()->setJs('columns', ArrayLiteral::set($this->getColumnsDefinition()));
         $this->getTemplate()->setJs('itemsPerPage', Integer::set($this->paginatorItemsPerPage));
-        $this->getTemplate()->setJs('tableActions', ObjectLiteral::set($this->actions));
+        $this->getTemplate()->setJs('tableRowActions', ObjectLiteral::set($this->actions));
     }
 
     private function getColumnsDefinition(): array

--- a/src/Component/Table.php
+++ b/src/Component/Table.php
@@ -138,10 +138,10 @@ class Table extends View implements VueInterface
     /**
      * Add a table action to table action region in template.
      * Return a TriggerCtrl where onTrigger is used to perform the callback action.
-     * The onTrigger closure function received the ids select by user.
-     * ex: $table->addTableAction($myAction)->onTrigger(function($ids): JsRenderInterface {});.
+     * The onTrigger closure function received the ids of rows select by user.
+     * ex: $table->addRowsAction($myAction)->onTrigger(function($ids): JsRenderInterface {});.
      */
-    public function addTableAction(Action $action): TriggerCtrl
+    public function addRowsAction(Action $action): TriggerCtrl
     {
         $this->hasSelectableRows = true;
         $this->addView($action, self::TABLE_ACTION_REGION);

--- a/src/Component/Table.php
+++ b/src/Component/Table.php
@@ -137,8 +137,8 @@ class Table extends View implements VueInterface
 
     /**
      * Add a table action to table action region in template.
-     * Return a TriggerCtrl where you can use onTrigger to perform
-     * the callback action.
+     * Return a TriggerCtrl where onTrigger is used to perform the callback action.
+     * The onTrigger closure function received the ids select by user.
      * ex: $table->addTableAction($myAction)->onTrigger(function($ids): JsRenderInterface {});.
      */
     public function addTableAction(Action $action): TriggerCtrl

--- a/src/Component/Table/Action.php
+++ b/src/Component/Table/Action.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Create an action that can be trigger using multiple rows selected.
+ */
+
+namespace Fohn\Ui\Component\Table;
+
+use Fohn\Ui\Callback\Ajax;
+use Fohn\Ui\Component\VueTrait;
+use Fohn\Ui\View;
+
+class Action extends View
+{
+    use VueTrait;
+
+    public string $defaultTemplate = 'vue-component/table/table-action.html';
+
+    /** Keep selection after action is trigger. */
+    public bool $keepSelection = false;
+    /** Reload table data after action is trigger. */
+    public bool $reloadTable = false;
+    protected ?View\Button $trigger = null;
+    protected ?Ajax $cb = null;
+
+    protected function initRenderTree(): void
+    {
+        parent::initRenderTree();
+        $this->cb = Ajax::addAbstractTo($this);
+    }
+
+    public function getCallback(): Ajax
+    {
+        return $this->cb;
+    }
+
+    public function setTrigger(View\Button $btn): self
+    {
+        $this->trigger = $btn;
+        $this->addView($btn);
+
+        return $this;
+    }
+
+    protected function beforeHtmlRender(): void
+    {
+        $this->getTemplate()->set('actionUrl', $this->cb->getUrl());
+        static::bindVueEvent($this->trigger, 'click', 'execute');
+        static::bindVueAttr($this->trigger, 'disabled', '!isEnable');
+
+        parent::beforeHtmlRender();
+    }
+}

--- a/src/Component/Table/Action.php
+++ b/src/Component/Table/Action.php
@@ -47,7 +47,7 @@ class Action extends View
     {
         $this->getTemplate()->set('actionUrl', $this->cb->getUrl());
         static::bindVueEvent($this->trigger, 'click', 'execute');
-        static::bindVueAttr($this->trigger, 'disabled', '!isEnable');
+        static::bindVueAttr($this->trigger, 'disabled', '!isEnable || isTableFetching');
 
         parent::beforeHtmlRender();
     }

--- a/src/Component/Table/Action.php
+++ b/src/Component/Table/Action.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Fohn\Ui\Component\Table;
 
 use Fohn\Ui\Callback\Ajax;
+use Fohn\Ui\Component\Modal\AsDialog;
 use Fohn\Ui\Component\VueTrait;
 use Fohn\Ui\View;
 

--- a/src/Component/Table/Action.php
+++ b/src/Component/Table/Action.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 namespace Fohn\Ui\Component\Table;
 
 use Fohn\Ui\Callback\Ajax;
-use Fohn\Ui\Component\Modal\AsDialog;
 use Fohn\Ui\Component\VueTrait;
 use Fohn\Ui\View;
 
@@ -18,6 +17,7 @@ class Action extends View
 
     public string $defaultTemplate = 'vue-component/table/table-action.html';
 
+    public bool $requireSelection = true;
     /** Keep selection after action is trigger. */
     public bool $keepSelection = false;
     /** Reload table data after action is trigger. */

--- a/src/Component/Table/Action.php
+++ b/src/Component/Table/Action.php
@@ -9,6 +9,7 @@ namespace Fohn\Ui\Component\Table;
 
 use Fohn\Ui\Callback\Ajax;
 use Fohn\Ui\Component\Modal\AsDialog;
+use Fohn\Ui\Component\Table\Action\Messages;
 use Fohn\Ui\Component\VueTrait;
 use Fohn\Ui\Js\Js;
 use Fohn\Ui\View;
@@ -40,21 +41,22 @@ class Action extends View
         return $this->cb;
     }
 
-    public function getConfirmationModal(): AsDialog
+    public function getConfirmationModal(): ?AsDialog
     {
         return $this->confirmationModal;
     }
 
-    public function addConfirmationDialog(string $title, string $msg, View\Button $ok = null, View\Button $cancel = null, bool $isClosable = true): self
+    public function addConfirmationDialog(string $title, Messages $messages, View\Button $ok = null, View\Button $cancel = null, bool $isClosable = true): self
     {
+        $this->addProperty('messages', $messages->getJsMessages());
         $this->confirmationModal = AsDialog::addTo($this, ['title' => $title, 'isClosable' => $isClosable]);
-        $this->confirmationModal->setTextContent($msg);
         if (!$isClosable) {
-            $this->confirmationModal->addCancelEvent();
+            $this->confirmationModal->addCancelEvent(null, $cancel);
         }
 
-        $trigger = $this->confirmationModal->addConfirmEvent();
+        $trigger = $this->confirmationModal->addConfirmEvent(null, $ok);
         $this->confirmationModal->addEvent('on-confirm', Js::var('execute($event)'));
+        $this->confirmationModal->addProperty('message', Js::var('actionMsg'));
         static::bindVueEvent($trigger, 'click', 'confirm');
 
         return $this;
@@ -79,6 +81,7 @@ class Action extends View
         static::bindVueAttr($this->trigger, 'disabled', '!isEnable || isTableFetching');
 
         $this->renderEvents();
+        $this->renderProperties();
         parent::beforeHtmlRender();
     }
 }

--- a/src/Component/Table/Action/Messages.php
+++ b/src/Component/Table/Action/Messages.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * User messages that display within a confirmation dialog
+ * when a table action is to be executed.
+ * Default placeholder for user selections count is {#}.
+ */
+
+namespace Fohn\Ui\Component\Table\Action;
+
+use Fohn\Ui\Js\Js;
+use Fohn\Ui\Js\JsRenderInterface;
+
+class Messages
+{
+    /** Message value to display when no row are selected. */
+    public string $none = '';
+    /** Message value to display when only one row is selected. */
+    public string $single = '';
+    /** Message value to display when more than one row is selected. */
+    public string $multiple = '';
+
+    public function getJsMessages(): JsRenderInterface
+    {
+        return Js::object(['none' => $this->none, 'single' => $this->single, 'multiple' => $this->multiple]);
+    }
+}

--- a/src/Component/Table/Action/TriggerCtrl.php
+++ b/src/Component/Table/Action/TriggerCtrl.php
@@ -23,7 +23,7 @@ class TriggerCtrl
     {
         $extra = ['state' => ['reload' => $this->tableAction->reloadTable, 'keepSelection' => $this->tableAction->keepSelection]];
         $this->tableAction->getCallback()->onAjaxPostRequest(function (array $payload) use ($fx): JsRenderInterface {
-            return $fx($payload['ids']);
+            return $fx($payload['ids'], $this->tableAction->getConfirmationModal());
         }, $extra);
     }
 }

--- a/src/Component/Table/Action/TriggerCtrl.php
+++ b/src/Component/Table/Action/TriggerCtrl.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Perform a callback request event from a Table/Action view.
+ */
+
+namespace Fohn\Ui\Component\Table\Action;
+
+use Fohn\Ui\Component\Table\Action;
+use Fohn\Ui\Js\JsRenderInterface;
+
+class TriggerCtrl
+{
+    private Action $tableAction;
+
+    public function __construct(Action $tableAction)
+    {
+        $this->tableAction = $tableAction;
+    }
+
+    public function onTrigger(\Closure $fx): void
+    {
+        $extra = ['state' => ['reload' => $this->tableAction->reloadTable, 'keepSelection' => $this->tableAction->keepSelection]];
+        $this->tableAction->getCallback()->onAjaxPostRequest(function (array $payload) use ($fx): JsRenderInterface {
+            return $fx($payload['ids']);
+        }, $extra);
+    }
+}

--- a/src/Component/VueTrait.php
+++ b/src/Component/VueTrait.php
@@ -21,6 +21,10 @@ trait VueTrait
     /** Vue Pinia store id. Must be unique. */
     protected ?string $storeId = null;
 
+    protected array $properties = [];
+
+    protected array $events = [];
+
     /**
      * Bind a Vue v-on:event to a View via html attributes.
      * <button v-on:click="do something"></button>.
@@ -81,6 +85,31 @@ trait VueTrait
         }
 
         return $isRoot;
+    }
+
+    protected function renderProperties(): void
+    {
+        $props = '';
+        foreach ($this->properties as $k => $v) {
+            $props .= $k . '="' . $v . '"';
+        }
+
+        $this->getTemplate()->tryDangerouslySetHtml('properties', $props);
+    }
+
+    public function addEvent(string $event, JsRenderInterface $declaration): void
+    {
+        $this->events['@' . $event] = $declaration->jsRender();
+    }
+
+    protected function renderEvents(): void
+    {
+        $props = '';
+        foreach ($this->events as $k => $v) {
+            $props .= $k . '="' . $v . '"';
+        }
+
+        $this->getTemplate()->tryDangerouslySetHtml('events', $props);
     }
 
     protected function jsGetStore(string $prefix): JsRenderInterface

--- a/src/Component/VueTrait.php
+++ b/src/Component/VueTrait.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Fohn\Ui\Component;
 
+use Fohn\Ui\Core\Exception;
 use Fohn\Ui\Js\JsChain;
 use Fohn\Ui\Js\JsRenderInterface;
 use Fohn\Ui\Service\Ui;
@@ -19,6 +20,17 @@ trait VueTrait
 
     /** Vue Pinia store id. Must be unique. */
     protected ?string $storeId = null;
+
+    /**
+     * Bind a Vue v-on:event to a View via html attributes.
+     */
+    public static function bindVueEvent(View $view, string $eventName, string $event): void
+    {
+        if (!$view->getTemplate()->hasTag('attributes')) {
+            throw new Exception('Unable to bind Vue event. Template for View does not have the attributes tag.');
+        }
+        $view->appendHtmlAttribute('v-on:' . $eventName, $event);
+    }
 
     protected function getDefaultSelector(): string
     {

--- a/src/Component/VueTrait.php
+++ b/src/Component/VueTrait.php
@@ -23,13 +23,27 @@ trait VueTrait
 
     /**
      * Bind a Vue v-on:event to a View via html attributes.
+     * <button v-on:click="do something"></button>.
      */
     public static function bindVueEvent(View $view, string $eventName, string $event): void
     {
-        if (!$view->getTemplate()->hasTag('attributes')) {
+        if (!$view->getTemplate()->hasTag(View::ATTR_TEMPLATE_TAG)) {
             throw new Exception('Unable to bind Vue event. Template for View does not have the attributes tag.');
         }
         $view->appendHtmlAttribute('v-on:' . $eventName, $event);
+    }
+
+    /**
+     * Bind a dynamic attribute to a view.
+     * <div :disabled="{isLoading}"></div>.
+     */
+    public static function bindVueAttr(View $view, string $attr, string $value): void
+    {
+        if (!$view->getTemplate()->hasTag(View::ATTR_TEMPLATE_TAG)) {
+            throw new Exception('Unable to bind Vue attribute. Template for View does not have the attributes tag.');
+        }
+
+        $view->appendHtmlAttribute(':' . $attr, $value);
     }
 
     protected function getDefaultSelector(): string

--- a/src/Component/VueTrait.php
+++ b/src/Component/VueTrait.php
@@ -87,6 +87,13 @@ trait VueTrait
         return $isRoot;
     }
 
+    public function addProperty(string $property, JsRenderInterface $value, bool $isDynamic = true): self
+    {
+        $this->properties[($isDynamic ? ':' : '') . $property] = $value->jsRender();
+
+        return $this;
+    }
+
     protected function renderProperties(): void
     {
         $props = '';

--- a/src/Page.php
+++ b/src/Page.php
@@ -93,7 +93,7 @@ class Page extends View
         return $this->layout;
     }
 
-    public function beforeHtmlRender(): void
+    protected function beforeHtmlRender(): void
     {
         if ($this->toastSelector) {
             // @phpstan-ignore-next-line

--- a/src/Service/Ui.php
+++ b/src/Service/Ui.php
@@ -418,16 +418,7 @@ class Ui implements UiInterface
         return JsChain::with(static::service()->jsLibrary)->utils()->browser()->redirect($url, Type::factory($param));
     }
 
-    /**
-     * Bind a Vue v-on:event to a View via html attributes.
-     */
-    public static function bindVueEvent(View $view, string $eventName, string $event): void
-    {
-        if (!$view->getTemplate()->hasTag('attributes')) {
-            throw new Exception('Unable to bind Vue event. Template for View does not have the attributes tag.');
-        }
-        $view->appendHtmlAttribute('v-on:' . $eventName, $event);
-    }
+
 
     public static function copyView(View $view): View
     {

--- a/src/Service/Ui.php
+++ b/src/Service/Ui.php
@@ -418,8 +418,6 @@ class Ui implements UiInterface
         return JsChain::with(static::service()->jsLibrary)->utils()->browser()->redirect($url, Type::factory($param));
     }
 
-
-
     public static function copyView(View $view): View
     {
         /** @var View $viewCopy */

--- a/src/Service/UiInterface.php
+++ b/src/Service/UiInterface.php
@@ -57,8 +57,6 @@ interface UiInterface
 
     public static function renderException(\Throwable $exception): string;
 
-    public static function bindVueEvent(View $view, string $eventName, string $event): void;
-
     /**
      * Create View objects using seed.
      *

--- a/src/View.php
+++ b/src/View.php
@@ -21,11 +21,11 @@ class View extends AbstractView
     public const AFTER_TEMPLATE_REGION = HtmlTemplate::AFTER_TEMPLATE_TAG;
     public const BEFORE_TEMPLATE_REGION = HtmlTemplate::BEFORE_TEMPLATE_TAG;
 
-    protected const CLASS_TEMPLATE_TAG = 'classAttr';
-    protected const ID_TEMPLATE_TAG = 'idAttr';
-    protected const STYLE_TEMPLATE_TAG = 'styleAttr';
-    protected const ATTR_TEMPLATE_TAG = 'attributes';
-    protected const TAG_TEMPLATE_TAG = 'htmlTag';
+    public const CLASS_TEMPLATE_TAG = 'classAttr';
+    public const ID_TEMPLATE_TAG = 'idAttr';
+    public const STYLE_TEMPLATE_TAG = 'styleAttr';
+    public const ATTR_TEMPLATE_TAG = 'attributes';
+    public const TAG_TEMPLATE_TAG = 'htmlTag';
 
     /** @var JsRenderInterface[] */
     private array $jsActions = [];

--- a/src/View.php
+++ b/src/View.php
@@ -364,7 +364,7 @@ class View extends AbstractView
             $attributes .= trim($attr) . '="' . trim((string) $val) . '" ';
         }
         if ($attributes) {
-            $this->getTemplate()->trySet(self::ATTR_TEMPLATE_TAG, trim($attributes));
+            $this->getTemplate()->tryDangerouslySetHtml(self::ATTR_TEMPLATE_TAG, trim($attributes));
         }
     }
 

--- a/template/tailwind/vue-component/modal.html
+++ b/template/tailwind/vue-component/modal.html
@@ -28,7 +28,7 @@
                     leave-to-class="opacity-0 translate-y-10 translate-y-0 scale-95">
                 <div v-show="isOpen"
                      class=" overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 w-full inset-0 h-full"
-                     @click="closeModal">
+                     @click="() => closeModal(false)">
                     <div class="__fohn-modal {$modalClassAttr}"
                          @click.stop=""
                          :class="heightCss"
@@ -37,7 +37,7 @@
                             <div class="grid grid-cols-6 p-2">
                                 <div class="col-span-5">{{title}}</div>
                                 <div v-if="isClosable"><span class="bi bi-x float-right text-lg cursor-pointer"
-                                           @click="closeModal"></span></div>
+                                           @click="() => closeModal(false)"></span></div>
                             </div>
                         </div>
                         <div class="__fohn-modal-content p-5" >

--- a/template/tailwind/vue-component/modal.html
+++ b/template/tailwind/vue-component/modal.html
@@ -1,12 +1,12 @@
 <div id="{$idAttr}" class="{$classAttr}" {$attributes}>
     <teleport to="#fohn-modals" class="invisible">
-        <fohn-modal
+        <fohn-modal {$events} {$properties}
                 :store-id="{$storeId}"
                 :title="{$title}"
                 :is-closable="{$isClosable}"
                 :callbacks="{callbacks}''{/}"
                 :content-url="{contentUrl}''{/}"
-                #default="@{heightCss, title, isOpen, isLoading, closeModal, openModal, onCallback, message, hasRemoteContent, isClosable}">
+                #default="@{heightCss, title, isOpen, isLoading, closeModal, openModal, onCallback, message, hasRemoteContent, isClosable, confirm, cancel}">
             <!-- Overlay     -->
             <transition
                     enter-active-class="transition ease-out duration-200 transform"

--- a/template/tailwind/vue-component/modal.html
+++ b/template/tailwind/vue-component/modal.html
@@ -40,13 +40,11 @@
                                            @click="closeModal"></span></div>
                             </div>
                         </div>
-                        <div class="p-5" v-if="message">{{message}}</div>
-                        <div class="__fohn-modal-content p-5 min-h-[120px]" v-if="hasRemoteContent">
-                            <fohn-spinner :spin="isLoading" v-if="isLoading"
-                                          class="grid place-items-center"></fohn-spinner>
-                            {$remoteContent}
+                        <div class="__fohn-modal-content p-5" >
+                            <fohn-spinner v-if="hasRemoteContent && isLoading" :spin="isLoading" v-if="isLoading" class="grid place-items-center"></fohn-spinner>
+                            <div class="px-4" v-if="message">{{message}}</div>
+                            {$Content}
                         </div>
-                        {$Content}
                         <div class="sticky border-t border-gray-200 bottom-0 bg-white p-1">
                             <div class="grid place-content-end">
                                 <div>

--- a/template/tailwind/vue-component/table.html
+++ b/template/tailwind/vue-component/table.html
@@ -24,7 +24,7 @@
                 setItemsPerPage,
                 hasSelectableRows,
                 executeRowAction}">
-            <div class="" :class="@{'animate-pulse': isFetching}">
+            <div class="" >
                 {$beforeTable}
                 <div class="flex justify-start">
                     {$tableActions}
@@ -42,6 +42,7 @@
                                 @keyup="searchItems(query)"
                                 class="block w-full py-2 pl-10 mt-1 rounded-md border-gray-300 shadow-sm focus:border-blue-300 focus:ring-0 focus:ring-blue-200 focus:ring-opacity-50"
                                 placeholder="Search..."
+                                :disabled="isFetching"
                                 required
                         >
                         <button v-if="query" type="button" @click="clearSearch()" class="flex absolute inset-y-0 right-0 items-center pr-3">
@@ -51,7 +52,7 @@
                 </div>
                 {/TableSearch}
                 <div class="overflow-auto">
-                <table class="{$tableTws}" >
+                <table class="{$tableTws}" :class="@{'animate-pulse': isFetching}">
                     <caption>{$caption}</caption>
                     {TableHeaders}
                     <thead>

--- a/template/tailwind/vue-component/table.html
+++ b/template/tailwind/vue-component/table.html
@@ -6,6 +6,7 @@
                 :items-per-page="{$itemsPerPage}"
                 :columns="{$columns}"
                 :has-selectable-rows="{$hasSelectableRows}"
+                :keep-selection-across-page="{$keepSelectionAcrossPage}"
                 :row-actions="{$tableRowActions}"
                 :keep-table-state="{$keepTableState}"
                 #default="@{isFetching,
@@ -23,41 +24,57 @@
                 clearSearch,
                 setItemsPerPage,
                 hasSelectableRows,
+                selectedRowSize,
+                togglePageRows,
+                pageSelectState,
+                clearSelectedRows,
                 executeRowAction}">
             <div class="" >
                 {$beforeTable}
                 <div class="flex justify-start">
                     {$tableActions}
                 </div>
-                {TableSearch}
-                <div class="flex justify-end">
-                    <div class="flex relative w-64 py-2">
-                        <div class="flex absolute inset-y-0 left-0 items-center pl-3 pointer-events-none">
-                            <i class="bi bi-search"></i>
+                <div class="grid grid-cols-2">
+                    <div  class="flex justify-start mx-2 my-auto">
+                        <div v-if="hasSelectableRows">
+                            <span class="text-sm italic">Selected row: {{selectedRowSize}}</span>
+                            <span v-if="selectedRowSize > 0" @click="clearSelectedRows"><i class="mx-1 bi bi-x-circle-fill text-red-600 cursor-pointer"></i></span>
                         </div>
-                        <input
-                                type="text"
-                                v-model="query"
-                                name="_q"
-                                @keyup="searchItems(query)"
-                                class="block w-full py-2 pl-10 mt-1 rounded-md border-gray-300 shadow-sm focus:border-blue-300 focus:ring-0 focus:ring-blue-200 focus:ring-opacity-50"
-                                placeholder="Search..."
-                                :disabled="isFetching"
-                                required
-                        >
-                        <button v-if="query" type="button" @click="clearSearch()" class="flex absolute inset-y-0 right-0 items-center pr-3">
-                            <i class="bi bi-x"></i>
-                        </button>
                     </div>
+                    {TableSearch}
+                    <div class="flex justify-end">
+                        <div class="flex relative w-64 py-2">
+                            <div class="flex absolute inset-y-0 left-0 items-center pl-3 pointer-events-none">
+                                <i class="bi bi-search"></i>
+                            </div>
+                            <input
+                                    type="text"
+                                    v-model="query"
+                                    name="_q"
+                                    @keyup="searchItems(query)"
+                                    class="block w-full py-2 pl-10 mt-1 rounded-md border-gray-300 shadow-sm focus:border-blue-300 focus:ring-0 focus:ring-blue-200 focus:ring-opacity-50"
+                                    placeholder="Search..."
+                                    :disabled="isFetching"
+                                    required
+                            >
+                            <button v-if="query" type="button" @click="clearSearch()" class="flex absolute inset-y-0 right-0 items-center pr-3">
+                                <i class="bi bi-x"></i>
+                            </button>
+                        </div>
+                    </div>
+                    {/TableSearch}
                 </div>
-                {/TableSearch}
                 <div class="overflow-auto">
                 <table class="{$tableTws}" :class="@{'animate-pulse': isFetching}">
                     <caption>{$caption}</caption>
                     {TableHeaders}
                     <thead>
                     <tr class="{$headRowTws} bg-gray-100">
-                        <td v-if="hasSelectableRows"><i class="bi bi-square"></i></td>
+                        <td v-if="hasSelectableRows">
+                            <div class="flex items-center mx-1 cursor-pointer" @click="togglePageRows">
+                                <i :class="{'bi bi-square': pageSelectState.none, 'bi bi-check-square' : pageSelectState.all, 'bi bi-dash-square' : pageSelectState.partial} "></i>
+                            </div>
+                        </td>
                         <template v-for="column in columns" >
                             <fohn-header-cell :column="column" :sort-column="sortColumn" :sort-direction="sortDirection" @sort-table="sortTable">
                                 {$headers}
@@ -71,7 +88,11 @@
                             <fohn-table-row :row="row" :has-selection="hasSelectableRows">
                                 <template #default="@{row, isEvenRow, isActionable, isSelected, toggleRow}" >
                                     <tr :data-id="row.id" :class="row.css" class="{$rowTws}" @click="toggleRow(row.id)">
-                                        <td v-if="isActionable"><i :class="{'bi bi-check-square': isSelected, 'bi bi-square': !isSelected}"></i></td>
+                                        <td v-if="isActionable">
+                                            <div class="flex items-center mx-1 cursor-pointer">
+                                                <i :class="{'bi bi-check-square': isSelected, 'bi bi-square': !isSelected}"></i>
+                                            </div>
+                                        </td>
                                         <template v-for="column in columns">
                                             <fohn-table-cell :cell="row.cells[column.name]">
                                                 {$cells}

--- a/template/tailwind/vue-component/table.html
+++ b/template/tailwind/vue-component/table.html
@@ -5,7 +5,8 @@
                 data-url="{$dataUrl}"
                 :items-per-page="{$itemsPerPage}"
                 :columns="{$columns}"
-                :actions="{$tableActions}"
+                :has-selectable-rows="{$hasSelectableRows}"
+                :row-actions="{$tableRowActions}"
                 :keep-table-state="{$keepTableState}"
                 #default="@{isFetching,
                 query,
@@ -21,9 +22,13 @@
                 sortTable,
                 clearSearch,
                 setItemsPerPage,
-                executeAction}">
+                hasSelectableRows,
+                executeRowAction}">
             <div class="" :class="@{'animate-pulse': isFetching}">
                 {$beforeTable}
+                <div class="flex justify-start">
+                    {$tableActions}
+                </div>
                 {TableSearch}
                 <div class="flex justify-end">
                     <div class="flex relative w-64 py-2">
@@ -51,6 +56,7 @@
                     {TableHeaders}
                     <thead>
                     <tr class="{$headRowTws} bg-gray-100">
+                        <td v-if="hasSelectableRows"><i class="bi bi-square"></i></td>
                         <template v-for="column in columns" >
                             <fohn-header-cell :column="column" :sort-column="sortColumn" :sort-direction="sortDirection" @sort-table="sortTable">
                                 {$headers}
@@ -61,9 +67,10 @@
                     {/TableHeaders}
                     <tbody>
                         <template v-for="(row, idx) in rows" :key="idx">
-                            <fohn-table-row :row="row">
-                                <template #default="@{row}" >
-                                    <tr :data-id="row.id" :class="row.css" class="{$rowTws}">
+                            <fohn-table-row :row="row" :has-selection="hasSelectableRows">
+                                <template #default="@{row, isEvenRow, isActionable, isSelected, toggleRow}" >
+                                    <tr :data-id="row.id" :class="row.css" class="{$rowTws}" @click="toggleRow(row.id)">
+                                        <td v-if="isActionable"><i :class="{'bi bi-check-square': isSelected, 'bi bi-square': !isSelected}"></i></td>
                                         <template v-for="column in columns">
                                             <fohn-table-cell :cell="row.cells[column.name]">
                                                 {$cells}

--- a/template/tailwind/vue-component/table/table-action.html
+++ b/template/tailwind/vue-component/table/table-action.html
@@ -1,8 +1,8 @@
 <div id="{$idAttr}"  class="{$classAttr}" {$attributes}>
     <fohn-table-action
-            disabled
+        :is-table-fetching="isFetching"
         action-url="{$actionUrl}"
-        #default="@{execute, isEnable}">
+        #default="@{execute, isEnable, isTableFetching}">
        {$Content}
     </fohn-table-action>
 </div>

--- a/template/tailwind/vue-component/table/table-action.html
+++ b/template/tailwind/vue-component/table/table-action.html
@@ -1,5 +1,6 @@
 <div id="{$idAttr}"  class="{$classAttr}" {$attributes}>
     <fohn-table-action
+        :table-rows-selected="selectedRowSize"
         :is-table-fetching="isFetching"
         action-url="{$actionUrl}"
         #default="@{execute, isEnable, isTableFetching}">

--- a/template/tailwind/vue-component/table/table-action.html
+++ b/template/tailwind/vue-component/table/table-action.html
@@ -1,0 +1,8 @@
+<div id="{$idAttr}"  class="{$classAttr}" {$attributes}>
+    <fohn-table-action
+            disabled
+        action-url="{$actionUrl}"
+        #default="@{execute, isEnable}">
+       {$Content}
+    </fohn-table-action>
+</div>

--- a/template/tailwind/vue-component/table/table-action.html
+++ b/template/tailwind/vue-component/table/table-action.html
@@ -1,9 +1,9 @@
 <div id="{$idAttr}"  class="{$classAttr}" {$attributes}>
-    <fohn-table-action
+    <fohn-table-action {$properties}
         :table-rows-selected="selectedRowSize"
         :is-table-fetching="isFetching"
         action-url="{$actionUrl}"
-        #default="@{execute, isEnable, isTableFetching}" >
+        #default="@{execute, isEnable, isTableFetching, actionMsg}" >
        {$Content}
     </fohn-table-action>
 </div>

--- a/template/tailwind/vue-component/table/table-action.html
+++ b/template/tailwind/vue-component/table/table-action.html
@@ -3,7 +3,7 @@
         :table-rows-selected="selectedRowSize"
         :is-table-fetching="isFetching"
         action-url="{$actionUrl}"
-        #default="@{execute, isEnable, isTableFetching}">
+        #default="@{execute, isEnable, isTableFetching}" >
        {$Content}
     </fohn-table-action>
 </div>


### PR DESCRIPTION
- Add row selection columns for action that required selection
  - Selection can be made across multiple pages;
- Table can be reload or selection be kept after action callback has run;
- Add confirmation modal;

usage: 
```
$actionDelete = (new Table\Action(['reloadTable' => true]))->setTrigger(Button::factory(['label' => 'Delete', 'color' => 'neutral']));
$actionMsg = new Table\Action\Messages();
$actionMsg->single = 'This action will delete 1 country. Are you sure?';
$actionMsg->multiple = 'This action will delete {#} countries. Are you sure?';

$actionDelete->addConfirmationDialog('Delete countries:', $actionMsg);
$table->addRowsAction($actionDelete)->onTrigger(function ($ids, $dialog) {
    // performs deletes on ids
    return JsStatements::with([JsToast::success('Delete Action! ' . implode(' / ', $ids)), $dialog->jsClose()]);
});
```

#### Note: Required Fohn-js version 1.5

<img width="828" alt="Screenshot 2023-09-03 at 10 24 27 AM" src="https://github.com/Fohn-Group/fohn-ui/assets/2204478/bb893519-6630-4443-b325-bd70fa8165c3">
